### PR TITLE
bugfixes of proxies not handling Object.equals(Object) calls correctly.

### DIFF
--- a/src/com/mysql/jdbc/MultiHostConnectionProxy.java
+++ b/src/com/mysql/jdbc/MultiHostConnectionProxy.java
@@ -85,7 +85,13 @@ public abstract class MultiHostConnectionProxy implements InvocationHandler {
         }
 
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-            Object result = null;
+			final String methodName = method.getName();
+			if (METHOD_EQUALS.equals(methodName)) {
+				// Let args[0] "unwrap" to its InvocationHandler if it is a proxy.
+				return args[0].equals(this);
+			}
+
+			Object result = null;
 
             try {
                 result = method.invoke(this.invokeOn, args);

--- a/src/com/mysql/jdbc/interceptors/ResultSetScannerInterceptor.java
+++ b/src/com/mysql/jdbc/interceptors/ResultSetScannerInterceptor.java
@@ -37,6 +37,7 @@ import com.mysql.jdbc.Statement;
 import com.mysql.jdbc.StatementInterceptor;
 
 public class ResultSetScannerInterceptor implements StatementInterceptor {
+    private static final String METHOD_EQUALS = "equals";
 
     protected Pattern regexP;
 
@@ -68,10 +69,13 @@ public class ResultSetScannerInterceptor implements StatementInterceptor {
                 new InvocationHandler() {
 
                     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+						final String methodName = method.getName();
+						if (METHOD_EQUALS.equals(methodName)) {
+							// Let args[0] "unwrap" to its InvocationHandler if it is a proxy.
+							return args[0].equals(this);
+						}
 
                         Object invocationResult = method.invoke(finalResultSet, args);
-
-                        String methodName = method.getName();
 
                         if (invocationResult != null && invocationResult instanceof String || "getString".equals(methodName) || "getObject".equals(methodName)
                                 || "getObjectStoredProc".equals(methodName)) {

--- a/src/com/mysql/jdbc/jdbc2/optional/WrapperBase.java
+++ b/src/com/mysql/jdbc/jdbc2/optional/WrapperBase.java
@@ -37,6 +37,8 @@ import com.mysql.jdbc.SQLError;
  * Base class for all wrapped instances created by LogicalHandle
  */
 abstract class WrapperBase {
+    private static final String METHOD_EQUALS = "equals";
+
     protected MysqlPooledConnection pooledConnection;
 
     /**
@@ -73,6 +75,12 @@ abstract class WrapperBase {
         }
 
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+			final String methodName = method.getName();
+			if (METHOD_EQUALS.equals(methodName)) {
+				// Let args[0] "unwrap" to its InvocationHandler if it is a proxy.
+				return args[0].equals(this);
+			}
+
             Object result = null;
 
             try {


### PR DESCRIPTION
At least for the replicating driver this causes C3P0 malfunction. When using the replicating driver PreparedStatements are dynamic proxies. Since Object.equals(Object) is not dealt with but passed through, the calls become PreparedStatement.equals(Proxy) and never yield true. This means, the PreparedStatement is not equal to itself!

In C3P0 linked lists are used for keeping track of PreparedStatements. Unlike hash maps, the linked lists do not short-circuit equals calls for reference equality. As a result the remove operation on the linked list fails.

I'll contribute a guard statement protecting against the error to C3P0. The problem must be solved in MySQL driver codebase however.
