### PR TITLE
//Fix for bug #80631 Any ResultSet.getString return garbled result wi…

### DIFF
--- a/src/com/mysql/jdbc/Field.java
+++ b/src/com/mysql/jdbc/Field.java
@@ -190,6 +190,13 @@ public class Field {
                 this.encoding = "UTF-16";
             }
 
+
+            // Fix chinese(or other non-ascii encoding) garbled in [mysql 5.7 JSON type]
+            // Use UTF-8 encoding , because mysql use utf8mb4 for storing JSON type  ;
+            if (this.mysqlType == MysqlDefs.FIELD_TYPE_JSON) {
+                this.encoding = "UTF-8";
+            }
+
             // Handle VARBINARY/BINARY (server doesn't have a different type for this
 
             boolean isBinary = isBinary();

--- a/src/com/mysql/jdbc/Field.java
+++ b/src/com/mysql/jdbc/Field.java
@@ -190,6 +190,12 @@ public class Field {
                 this.encoding = "UTF-16";
             }
 
+            // Fix chinese(or other non-ascii encoding) garbled in [mysql 5.7 JSON type]
+            // Use UTF-8 encoding , because mysql use utf8mb4 for JSON type store ;
+            if (this.mysqlType == MysqlDefs.FIELD_TYPE_JSON) {
+                this.encoding = "UTF-8";
+            }
+
             // Handle VARBINARY/BINARY (server doesn't have a different type for this
 
             boolean isBinary = isBinary();
@@ -330,8 +336,8 @@ public class Field {
     /**
      * Constructor used when communicating with pre 4.1 servers
      */
-    Field(MySQLConnection conn, byte[] buffer, int nameStart, int nameLength, int tableNameStart, int tableNameLength, int length, int mysqlType, short colFlag,
-            int colDecimals) throws SQLException {
+    Field(MySQLConnection conn, byte[] buffer, int nameStart, int nameLength, int tableNameStart, int tableNameLength, int length, int mysqlType,
+            short colFlag, int colDecimals) throws SQLException {
         this(conn, buffer, -1, -1, tableNameStart, tableNameLength, -1, -1, nameStart, nameLength, -1, -1, length, mysqlType, colFlag, colDecimals, -1, -1,
                 NO_CHARSET_INFO);
     }
@@ -781,8 +787,8 @@ public class Field {
     }
 
     private boolean isNativeDateTimeType() {
-        return (this.mysqlType == MysqlDefs.FIELD_TYPE_DATE || this.mysqlType == MysqlDefs.FIELD_TYPE_NEWDATE || this.mysqlType == MysqlDefs.FIELD_TYPE_DATETIME
-                || this.mysqlType == MysqlDefs.FIELD_TYPE_TIME || this.mysqlType == MysqlDefs.FIELD_TYPE_TIMESTAMP);
+        return (this.mysqlType == MysqlDefs.FIELD_TYPE_DATE || this.mysqlType == MysqlDefs.FIELD_TYPE_NEWDATE
+                || this.mysqlType == MysqlDefs.FIELD_TYPE_DATETIME || this.mysqlType == MysqlDefs.FIELD_TYPE_TIME || this.mysqlType == MysqlDefs.FIELD_TYPE_TIMESTAMP);
     }
 
     public void setConnection(MySQLConnection conn) {

--- a/src/com/mysql/jdbc/Field.java
+++ b/src/com/mysql/jdbc/Field.java
@@ -190,12 +190,6 @@ public class Field {
                 this.encoding = "UTF-16";
             }
 
-            // Fix chinese(or other non-ascii encoding) garbled in [mysql 5.7 JSON type]
-            // Use UTF-8 encoding , because mysql use utf8mb4 for JSON type store ;
-            if (this.mysqlType == MysqlDefs.FIELD_TYPE_JSON) {
-                this.encoding = "UTF-8";
-            }
-
             // Handle VARBINARY/BINARY (server doesn't have a different type for this
 
             boolean isBinary = isBinary();
@@ -336,8 +330,8 @@ public class Field {
     /**
      * Constructor used when communicating with pre 4.1 servers
      */
-    Field(MySQLConnection conn, byte[] buffer, int nameStart, int nameLength, int tableNameStart, int tableNameLength, int length, int mysqlType,
-            short colFlag, int colDecimals) throws SQLException {
+    Field(MySQLConnection conn, byte[] buffer, int nameStart, int nameLength, int tableNameStart, int tableNameLength, int length, int mysqlType, short colFlag,
+            int colDecimals) throws SQLException {
         this(conn, buffer, -1, -1, tableNameStart, tableNameLength, -1, -1, nameStart, nameLength, -1, -1, length, mysqlType, colFlag, colDecimals, -1, -1,
                 NO_CHARSET_INFO);
     }
@@ -787,8 +781,8 @@ public class Field {
     }
 
     private boolean isNativeDateTimeType() {
-        return (this.mysqlType == MysqlDefs.FIELD_TYPE_DATE || this.mysqlType == MysqlDefs.FIELD_TYPE_NEWDATE
-                || this.mysqlType == MysqlDefs.FIELD_TYPE_DATETIME || this.mysqlType == MysqlDefs.FIELD_TYPE_TIME || this.mysqlType == MysqlDefs.FIELD_TYPE_TIMESTAMP);
+        return (this.mysqlType == MysqlDefs.FIELD_TYPE_DATE || this.mysqlType == MysqlDefs.FIELD_TYPE_NEWDATE || this.mysqlType == MysqlDefs.FIELD_TYPE_DATETIME
+                || this.mysqlType == MysqlDefs.FIELD_TYPE_TIME || this.mysqlType == MysqlDefs.FIELD_TYPE_TIMESTAMP);
     }
 
     public void setConnection(MySQLConnection conn) {

--- a/src/testsuite/regression/ResultSetRegressionTest.java
+++ b/src/testsuite/regression/ResultSetRegressionTest.java
@@ -1,4 +1,4 @@
-/*
+﻿/*
   Copyright (c) 2002, 2016, Oracle and/or its affiliates. All rights reserved.
 
   The MySQL Connector/J is licensed under the terms of the GPLv2
@@ -4970,5 +4970,33 @@ public class ResultSetRegressionTest extends BaseTestCase {
         assertEquals(ts1, this.rs.getTimestamp(2));
         assertEquals(ts2, this.rs.getTimestamp(3));
         assertFalse(this.rs.next());
+    }
+
+
+    /**
+     * Tests fix for Bug#80631 - ResultSet.getString return garbled result with json type data
+     */
+    public void testBug80631() throws Exception {
+        //MySQL 5.7.9 (2015-10-21, General Availability)
+        if (!versionMeetsMinimum(5, 7, 9)) {
+            return;
+        }
+
+        createTable("testBug80631", "(row_id int, json_field json)");
+        String chinese = "{\"chinese\": \"\u4e2d\u6587\"}";
+        String japanese = "{\"japanese\": \"\u685c\"}";
+        String emoji = "{\"emoji\": \"\ue415\"}";
+
+        System.out.println("INSERT INTO testBug80631 VALUES (1, '" + chinese + "'), (2, '" + japanese + "'), (3, '" + emoji + "')");
+        this.stmt.executeUpdate("INSERT INTO testBug80631 VALUES (1, '" + chinese + "'), (2, '" + japanese + "'), (3, '" + emoji + "')");
+
+        this.rs = this.stmt.executeQuery("SELECT json_field FROM testBug80631 ORDER BY row_id ASC");
+
+        assertTrue(this.rs.next());
+        assertEquals(chinese, this.rs.getString(1));
+        assertTrue(this.rs.next());
+        assertEquals(japanese, this.rs.getString(1));
+        assertTrue(this.rs.next());
+        assertEquals(emoji, this.rs.getString(1));
     }
 }


### PR DESCRIPTION
http://bugs.mysql.com/bug.php?id=80631
//Fix for bug #80631 Any ResultSet.getString return garbled result with json type data

// Fix chinese(or other non-ascii encoding) garbled in [mysql 5.7 JSON type]
// Use UTF-8 encoding , because mysql use utf8mb4 for JSON type store ;

SORRY for formatted this file ,Eclipse did that.
