### PR TITLE
Fixed a bug in slow query detection

### DIFF
--- a/src/com/mysql/jdbc/ServerPreparedStatement.java
+++ b/src/com/mysql/jdbc/ServerPreparedStatement.java
@@ -1320,7 +1320,7 @@ public class ServerPreparedStatement extends PreparedStatement {
                     long elapsedTime = queryEndTime - begin;
 
                     if (logSlowQueries) {
-                        if (this.useAutoSlowLog) {
+                        if (!this.useAutoSlowLog) {
                             queryWasSlow = elapsedTime > this.connection.getSlowQueryThresholdMillis();
                         } else {
                             queryWasSlow = this.connection.isAbonormallyLongQuery(elapsedTime);


### PR DESCRIPTION
Hi, there is bug in a way ServerPreparedStatement detects slow queries:

```
         if (this.useAutoSlowLog) {
             queryWasSlow = elapsedTime > this.connection.getSlowQueryThresholdMillis();
         } else {
             queryWasSlow = this.connection.isAbonormallyLongQuery(elapsedTime);
             this.connection.reportQueryTime(elapsedTime);
         }    
```

Meantime in MysqlIO:

```
        if (!this.useAutoSlowLog) {
           logSlow = queryTime > this.connection.getSlowQueryThresholdMillis();
        } else {
           logSlow = this.connection.isAbonormallyLongQuery(queryTime);
           this.connection.reportQueryTime(queryTime);
        }
```

As a result I'm getting lots of strange messages like `Slow query (exceeded 500 ms., duration: 34 ms): as prepared: SELECT ...` with autoSlowLog set to false. Setting it to true is not gonna suit as a workaround, since it'll break MysqlIO.

Please consider this simple fix. 
