### PR TITLE
Dropping unsupported system properties as of mysql-server 8.0.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4624,7 +4624,7 @@ nn-nn-07 - Version 3.1.15
 
     - Added missing LONGTEXT type to DBMD.getColumns().
 
-    - Retrieve TX_ISOLATION from database for
+    - Retrieve TRANSACTION_ISOLATION from database for
       Connection.getTransactionIsolation() when the MySQL version
       supports it, instead of an instance variable.
 

--- a/src/generated/java/com/mysql/cj/x/protobuf/MysqlxExpect.java
+++ b/src/generated/java/com/mysql/cj/x/protobuf/MysqlxExpect.java
@@ -36,11 +36,11 @@ public final class MysqlxExpect {
       com.google.protobuf.MessageOrBuilder {
 
     /**
-     * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTX_COPY_PREV];</code>
+     * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTRANSACTION_COPY_PREV];</code>
      */
     boolean hasOp();
     /**
-     * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTX_COPY_PREV];</code>
+     * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTRANSACTION_COPY_PREV];</code>
      */
     com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation getOp();
 
@@ -194,47 +194,47 @@ public final class MysqlxExpect {
     public enum CtxOperation
         implements com.google.protobuf.ProtocolMessageEnum {
       /**
-       * <code>EXPECT_CTX_COPY_PREV = 0;</code>
+       * <code>EXPECT_CTRANSACTION_COPY_PREV = 0;</code>
        *
        * <pre>
        * copy the operations from the parent Expect-block
        * </pre>
        */
-      EXPECT_CTX_COPY_PREV(0, 0),
+      EXPECT_CTRANSACTION_COPY_PREV(0, 0),
       /**
-       * <code>EXPECT_CTX_EMPTY = 1;</code>
+       * <code>EXPECT_CTRANSACTION_EMPTY = 1;</code>
        *
        * <pre>
        * start with a empty set of operations
        * </pre>
        */
-      EXPECT_CTX_EMPTY(1, 1),
+      EXPECT_CTRANSACTION_EMPTY(1, 1),
       ;
 
       /**
-       * <code>EXPECT_CTX_COPY_PREV = 0;</code>
+       * <code>EXPECT_CTRANSACTION_COPY_PREV = 0;</code>
        *
        * <pre>
        * copy the operations from the parent Expect-block
        * </pre>
        */
-      public static final int EXPECT_CTX_COPY_PREV_VALUE = 0;
+      public static final int EXPECT_CTRANSACTION_COPY_PREV_VALUE = 0;
       /**
-       * <code>EXPECT_CTX_EMPTY = 1;</code>
+       * <code>EXPECT_CTRANSACTION_EMPTY = 1;</code>
        *
        * <pre>
        * start with a empty set of operations
        * </pre>
        */
-      public static final int EXPECT_CTX_EMPTY_VALUE = 1;
+      public static final int EXPECT_CTRANSACTION_EMPTY_VALUE = 1;
 
 
       public final int getNumber() { return value; }
 
       public static CtxOperation valueOf(int value) {
         switch (value) {
-          case 0: return EXPECT_CTX_COPY_PREV;
-          case 1: return EXPECT_CTX_EMPTY;
+          case 0: return EXPECT_CTRANSACTION_COPY_PREV;
+          case 1: return EXPECT_CTRANSACTION_EMPTY;
           default: return null;
         }
       }
@@ -965,13 +965,13 @@ public final class MysqlxExpect {
     public static final int OP_FIELD_NUMBER = 1;
     private com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation op_;
     /**
-     * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTX_COPY_PREV];</code>
+     * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTRANSACTION_COPY_PREV];</code>
      */
     public boolean hasOp() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
-     * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTX_COPY_PREV];</code>
+     * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTRANSACTION_COPY_PREV];</code>
      */
     public com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation getOp() {
       return op_;
@@ -1013,7 +1013,7 @@ public final class MysqlxExpect {
     }
 
     private void initFields() {
-      op_ = com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation.EXPECT_CTX_COPY_PREV;
+      op_ = com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation.EXPECT_CTRANSACTION_COPY_PREV;
       cond_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
@@ -1183,7 +1183,7 @@ public final class MysqlxExpect {
 
       public Builder clear() {
         super.clear();
-        op_ = com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation.EXPECT_CTX_COPY_PREV;
+        op_ = com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation.EXPECT_CTRANSACTION_COPY_PREV;
         bitField0_ = (bitField0_ & ~0x00000001);
         if (condBuilder_ == null) {
           cond_ = java.util.Collections.emptyList();
@@ -1310,21 +1310,21 @@ public final class MysqlxExpect {
       }
       private int bitField0_;
 
-      private com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation op_ = com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation.EXPECT_CTX_COPY_PREV;
+      private com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation op_ = com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation.EXPECT_CTRANSACTION_COPY_PREV;
       /**
-       * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTX_COPY_PREV];</code>
+       * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTRANSACTION_COPY_PREV];</code>
        */
       public boolean hasOp() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
-       * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTX_COPY_PREV];</code>
+       * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTRANSACTION_COPY_PREV];</code>
        */
       public com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation getOp() {
         return op_;
       }
       /**
-       * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTX_COPY_PREV];</code>
+       * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTRANSACTION_COPY_PREV];</code>
        */
       public Builder setOp(com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation value) {
         if (value == null) {
@@ -1336,11 +1336,11 @@ public final class MysqlxExpect {
         return this;
       }
       /**
-       * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTX_COPY_PREV];</code>
+       * <code>optional .Mysqlx.Expect.Open.CtxOperation op = 1 [default = EXPECT_CTRANSACTION_COPY_PREV];</code>
        */
       public Builder clearOp() {
         bitField0_ = (bitField0_ & ~0x00000001);
-        op_ = com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation.EXPECT_CTX_COPY_PREV;
+        op_ = com.mysql.cj.x.protobuf.MysqlxExpect.Open.CtxOperation.EXPECT_CTRANSACTION_COPY_PREV;
         onChanged();
         return this;
       }
@@ -1949,15 +1949,15 @@ public final class MysqlxExpect {
     java.lang.String[] descriptorData = {
       "\n\023mysqlx_expect.proto\022\rMysqlx.Expect\"\200\003\n" +
       "\004Open\022B\n\002op\030\001 \001(\0162 .Mysqlx.Expect.Open.C" +
-      "txOperation:\024EXPECT_CTX_COPY_PREV\022+\n\004con" +
+      "txOperation:\024EXPECT_CTRANSACTION_COPY_PREV\022+\n\004con" +
       "d\030\002 \003(\0132\035.Mysqlx.Expect.Open.Condition\032\306" +
       "\001\n\tCondition\022\025\n\rcondition_key\030\001 \002(\r\022\027\n\017c" +
       "ondition_value\030\002 \001(\014\022K\n\002op\030\003 \001(\01620.Mysql" +
       "x.Expect.Open.Condition.ConditionOperati" +
       "on:\rEXPECT_OP_SET\"<\n\022ConditionOperation\022" +
       "\021\n\rEXPECT_OP_SET\020\000\022\023\n\017EXPECT_OP_UNSET\020\001\"" +
-      ">\n\014CtxOperation\022\030\n\024EXPECT_CTX_COPY_PREV\020",
-      "\000\022\024\n\020EXPECT_CTX_EMPTY\020\001\"\007\n\005CloseB\031\n\027com." +
+      ">\n\014CtxOperation\022\030\n\024EXPECT_CTRANSACTION_COPY_PREV\020",
+      "\000\022\024\n\020EXPECT_CTRANSACTION_EMPTY\020\001\"\007\n\005CloseB\031\n\027com." +
       "mysql.cj.x.protobuf"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =

--- a/src/main/java/com/mysql/cj/core/exceptions/MysqlErrorNumbers.java
+++ b/src/main/java/com/mysql/cj/core/exceptions/MysqlErrorNumbers.java
@@ -603,7 +603,7 @@ public final class MysqlErrorNumbers {
     public final static int ER_DDL_LOG_ERROR = 1565; //SQLSTATE: HY000 Message: Error in DDL log
     public final static int ER_NULL_IN_VALUES_LESS_THAN = 1566; //SQLSTATE: HY000 Message: Not allowed to use NULL value in VALUES LESS THAN
     public final static int ER_WRONG_PARTITION_NAME = 1567; //SQLSTATE: HY000 Message: Incorrect partition name
-    public final static int ER_CANT_CHANGE_TX_ISOLATION = 1568; //SQLSTATE: 25001 Message: Transaction isolation level can't be changed while a transaction is in progress
+    public final static int ER_CANT_CHANGE_TRANSACTION_ISOLATION = 1568; //SQLSTATE: 25001 Message: Transaction isolation level can't be changed while a transaction is in progress
     public final static int ER_DUP_ENTRY_AUTOINCREMENT_CASE = 1569; //SQLSTATE: HY000 Message: ALTER TABLE causes auto_increment resequencing, resulting in duplicate entry '%s' for key '%s'
     public final static int ER_EVENT_MODIFY_QUEUE_ERROR = 1570; //SQLSTATE: HY000 Message: Internal scheduler error %d
     public final static int ER_EVENT_SET_VAR_ERROR = 1571; //SQLSTATE: HY000 Message: Error during starting/stopping of the scheduler. Error code %u
@@ -1319,7 +1319,7 @@ public final class MysqlErrorNumbers {
         mysqlToSql99State.put(MysqlErrorNumbers.ER_WRONG_VALUE_COUNT_ON_ROW, SQL_STATE_INSERT_VALUE_LIST_NO_MATCH_COL_LIST);
         mysqlToSql99State.put(MysqlErrorNumbers.ER_INVALID_USE_OF_NULL, SQL_STATE_NULL_VALUE_NOT_ALLOWED);
         mysqlToSql99State.put(MysqlErrorNumbers.ER_INVALID_ARGUMENT_FOR_LOGARITHM, SQL_STATE_INVALID_LOGARITHM_ARGUMENT);
-        mysqlToSql99State.put(MysqlErrorNumbers.ER_CANT_CHANGE_TX_ISOLATION, SQL_STATE_ACTIVE_SQL_TRANSACTION);
+        mysqlToSql99State.put(MysqlErrorNumbers.ER_CANT_CHANGE_TRANSACTION_ISOLATION, SQL_STATE_ACTIVE_SQL_TRANSACTION);
         mysqlToSql99State.put(MysqlErrorNumbers.ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION, SQL_STATE_READ_ONLY_SQL_TRANSACTION);
         mysqlToSql99State.put(MysqlErrorNumbers.ER_SP_NO_RECURSIVE_CREATE, SQL_STATE_SRE_PROHIBITED_SQL_STATEMENT_ATTEMPTED);
         mysqlToSql99State.put(MysqlErrorNumbers.ER_SP_NORETURNEND, SQL_STATE_SRE_FUNCTION_EXECUTED_NO_RETURN_STATEMENT);

--- a/src/main/java/com/mysql/cj/jdbc/ConnectionImpl.java
+++ b/src/main/java/com/mysql/cj/jdbc/ConnectionImpl.java
@@ -563,7 +563,7 @@ public class ConnectionImpl extends AbstractJdbcConnection implements JdbcConnec
      */
     private void checkTransactionIsolationLevel() {
 
-        String s = this.session.getServerVariable("tx_isolation");
+        String s = this.session.getServerVariable("transaction_isolation");
 
         if (s != null) {
             Integer intTI = mapTransIsolationNameToValue.get(s);
@@ -1272,7 +1272,7 @@ public class ConnectionImpl extends AbstractJdbcConnection implements JdbcConnec
 
         synchronized (getConnectionMutex()) {
             if (!this.useLocalSessionState.getValue()) {
-                String s = this.session.queryServerVariable("@@session.tx_isolation");
+                String s = this.session.queryServerVariable("@@session.transaction_isolation");
 
                 if (s != null) {
                     Integer intTI = mapTransIsolationNameToValue.get(s);
@@ -1591,7 +1591,7 @@ public class ConnectionImpl extends AbstractJdbcConnection implements JdbcConnec
         if (useSessionStatus && !this.session.isClosed() && versionMeetsMinimum(5, 6, 5) && !this.useLocalSessionState.getValue()
                 && this.readOnlyPropagatesToServer.getValue()) {
             try {
-                String s = this.session.queryServerVariable("@@session.tx_read_only");
+                String s = this.session.queryServerVariable("@@session.transaction_read_only");
                 if (s != null) {
                     return Integer.parseInt(s) != 0; // mysql has a habit of tri+ state booleans
                 }

--- a/src/main/java/com/mysql/cj/mysqla/MysqlaSession.java
+++ b/src/main/java/com/mysql/cj/mysqla/MysqlaSession.java
@@ -1013,12 +1013,14 @@ public class MysqlaSession extends AbstractSession implements Session, Serializa
                 queryBuf.append(", @@max_allowed_packet AS max_allowed_packet");
                 queryBuf.append(", @@net_buffer_length AS net_buffer_length");
                 queryBuf.append(", @@net_write_timeout AS net_write_timeout");
-                queryBuf.append(", @@query_cache_size AS query_cache_size");
-                queryBuf.append(", @@query_cache_type AS query_cache_type");
+                if (!versionMeetsMinimum(8, 0, 3)) {
+                    queryBuf.append(", @@query_cache_size AS query_cache_size");
+                    queryBuf.append(", @@query_cache_type AS query_cache_type");
+                }
                 queryBuf.append(", @@sql_mode AS sql_mode");
                 queryBuf.append(", @@system_time_zone AS system_time_zone");
                 queryBuf.append(", @@time_zone AS time_zone");
-                queryBuf.append(", @@tx_isolation AS tx_isolation");
+                queryBuf.append(", @@transaction_isolation AS transaction_isolation");
                 queryBuf.append(", @@wait_timeout AS wait_timeout");
 
                 PacketPayload resultPacket = sendCommand(this.commandBuilder.buildComQuery(getSharedSendPacket(), queryBuf.toString()), false, 0);
@@ -1331,7 +1333,7 @@ public class MysqlaSession extends AbstractSession implements Session, Serializa
 
         } catch (CJException sqlE) {
             if (getPropertySet().getBooleanReadableProperty(PropertyDefinitions.PNAME_dumpQueriesOnException).getValue()) {
-                String extractedSql = MysqlaUtils.extractSqlFromPacket(query, packet, endOfQueryPacketPosition,
+                String extractedSql = com.mysql.cj.mysqla.MysqlaUtils.extractSqlFromPacket(query, packet, endOfQueryPacketPosition,
                         getPropertySet().getIntegerReadableProperty(PropertyDefinitions.PNAME_maxQuerySizeToLog).getValue());
                 StringBuilder messageBuf = new StringBuilder(extractedSql.length() + 32);
                 messageBuf.append("\n\nQuery being executed when exception was thrown:\n");

--- a/src/test/java/testsuite/regression/ConnectionRegressionTest.java
+++ b/src/test/java/testsuite/regression/ConnectionRegressionTest.java
@@ -1600,7 +1600,7 @@ public class ConnectionRegressionTest extends BaseTestCase {
             loggedConn = getConnectionWithProps(props);
             loggedConn.getTransactionIsolation();
 
-            assertEquals(-1, StandardLogger.getBuffer().toString().indexOf("SHOW VARIABLES LIKE 'tx_isolation'"));
+            assertEquals(-1, StandardLogger.getBuffer().toString().indexOf("SHOW VARIABLES LIKE 'transaction_isolation'"));
         } finally {
             StandardLogger.dropBuffer();
             if (loggedConn != null) {
@@ -7012,7 +7012,7 @@ public class ConnectionRegressionTest extends BaseTestCase {
 
             assertEquals(serverVariables.get("system_time_zone"), session.getServerVariable("system_time_zone"));
             assertEquals(serverVariables.get("time_zone"), session.getServerVariable("time_zone"));
-            assertEquals(serverVariables.get("tx_isolation"), session.getServerVariable("tx_isolation"));
+            assertEquals(serverVariables.get("transaction_isolation"), session.getServerVariable("transaction_isolation"));
             assertEquals(serverVariables.get("wait_timeout"), session.getServerVariable("wait_timeout"));
             if (!versionMeetsMinimum(5, 5, 0)) {
                 assertEquals(serverVariables.get("language"), session.getServerVariable("language"));

--- a/src/test/java/testsuite/simple/ConnectionTest.java
+++ b/src/test/java/testsuite/simple/ConnectionTest.java
@@ -852,7 +852,7 @@ public class ConnectionTest extends BaseTestCase {
     /**
      * Tests whether or not the configuration 'useLocalSessionState' actually
      * prevents non-needed 'set autocommit=', 'set session transaction isolation
-     * ...' and 'show variables like tx_isolation' queries.
+     * ...' and 'show variables like transaction_isolation' queries.
      * 
      * @throws Exception
      *             if the test fails.
@@ -876,7 +876,7 @@ public class ConnectionTest extends BaseTestCase {
 
         String logAsString = StandardLogger.getBuffer().toString();
 
-        assertTrue(logAsString.indexOf("SET SESSION") == -1 && logAsString.indexOf("SHOW VARIABLES LIKE 'tx_isolation'") == -1
+        assertTrue(logAsString.indexOf("SET SESSION") == -1 && logAsString.indexOf("SHOW VARIABLES LIKE 'transaction_isolation'") == -1
                 && logAsString.indexOf("SET autocommit=") == -1);
     }
 
@@ -1709,7 +1709,7 @@ public class ConnectionTest extends BaseTestCase {
                 }
                 StandardLogger.startLoggingToBuffer();
                 localState.isReadOnly();
-                assertTrue(StandardLogger.getBuffer().toString().indexOf("select @@session.tx_read_only") == -1);
+                assertTrue(StandardLogger.getBuffer().toString().indexOf("select @@session.transaction_read_only") == -1);
             }
 
             Connection noOptimization = getConnectionWithProps("profileSQL=true,readOnlyPropagatesToServer=false");
@@ -1720,7 +1720,7 @@ public class ConnectionTest extends BaseTestCase {
                 assertTrue(StandardLogger.getBuffer().toString().indexOf("set session transaction read only") == -1);
                 StandardLogger.startLoggingToBuffer();
                 noOptimization.isReadOnly();
-                assertTrue(StandardLogger.getBuffer().toString().indexOf("select @@session.tx_read_only") == -1);
+                assertTrue(StandardLogger.getBuffer().toString().indexOf("select @@session.transaction_read_only") == -1);
             }
         } finally {
             StandardLogger.dropBuffer();


### PR DESCRIPTION
TX_* renamed to TRANSACTION_*

query_cache_* no longer supported.