### PR TITLE
Fix for #88021 high GC pressure when driver configured with serversid…

### DIFF
--- a/src/com/mysql/jdbc/PerConnectionLRUFactory.java
+++ b/src/com/mysql/jdbc/PerConnectionLRUFactory.java
@@ -40,13 +40,13 @@ public class PerConnectionLRUFactory implements CacheAdapterFactory<String, Pars
 
     class PerConnectionLRU implements CacheAdapter<String, ParseInfo> {
         private final int cacheSqlLimit;
-        private final LRUCache cache;
+        private final LRUCache<String, ParseInfo> cache;
         private final Connection conn;
 
         protected PerConnectionLRU(Connection forConnection, int cacheMaxSize, int maxKeySize) {
             final int cacheSize = cacheMaxSize;
             this.cacheSqlLimit = maxKeySize;
-            this.cache = new LRUCache(cacheSize);
+            this.cache = new LRUCache<String, ParseInfo>(cacheSize);
             this.conn = forConnection;
         }
 

--- a/src/com/mysql/jdbc/util/LRUCache.java
+++ b/src/com/mysql/jdbc/util/LRUCache.java
@@ -26,7 +26,7 @@ package com.mysql.jdbc.util;
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 
-public class LRUCache extends LinkedHashMap<Object, Object> {
+public class LRUCache<K, V> extends LinkedHashMap<K, V> {
     private static final long serialVersionUID = 1L;
     protected int maxElements;
 
@@ -41,7 +41,7 @@ public class LRUCache extends LinkedHashMap<Object, Object> {
      * @see java.util.LinkedHashMap#removeEldestEntry(java.util.Map.Entry)
      */
     @Override
-    protected boolean removeEldestEntry(Entry<Object, Object> eldest) {
+    protected boolean removeEldestEntry(Entry<K, V> eldest) {
         return (size() > this.maxElements);
     }
 }


### PR DESCRIPTION
…eprepared statements.

While profiling our application I found high GC pressure coming from the mysql driver [1]. The issue arises when the driver is configured to use serverside prepared statements and the driver recreates the cache key for every query (sb.toString() invoking Arrays.copyOfRange) [2].

[1]

```text
Stack Trace    TLABs    Total TLAB Size(bytes)    Pressure(%)
com.mysql.jdbc.ConnectionImpl.makePreparedStatementCacheKey(String, String)    16,810    1,519,493,352
```
[2]

```java
private String makePreparedStatementCacheKey(String catalog, String query) {
    StringBuilder key = new StringBuilder();
    key.append("/*").append(catalog).append("*/");
    key.append(query);
    return key.toString();
}
```