### PR TITLE
ResultMetadata: columnTypeName should return *text when blob is not binary

### DIFF
--- a/src/com/mysql/jdbc/ResultSetMetaData.java
+++ b/src/com/mysql/jdbc/ResultSetMetaData.java
@@ -327,13 +327,22 @@ public class ResultSetMetaData implements java.sql.ResultSetMetaData {
                 return "DATETIME";
 
             case MysqlDefs.FIELD_TYPE_TINY_BLOB:
-                return "TINYBLOB";
+                if (getField(column).isBinary()) {
+                    return "TINYBLOB";
+                }
+                return "TINYTEXT";
 
             case MysqlDefs.FIELD_TYPE_MEDIUM_BLOB:
-                return "MEDIUMBLOB";
+                if (getField(column).isBinary()) {
+                    return "MEDIUMBLOB";
+                }
+                return "MEDIUMTEXT";
 
             case MysqlDefs.FIELD_TYPE_LONG_BLOB:
-                return "LONGBLOB";
+                if (getField(column).isBinary()) {
+                    return "LONGBLOB";
+                }
+                return "LONGTEXT";
 
             case MysqlDefs.FIELD_TYPE_BLOB:
                 if (getField(column).isBinary()) {

--- a/src/testsuite/regression/MetaDataRegressionTest.java
+++ b/src/testsuite/regression/MetaDataRegressionTest.java
@@ -221,6 +221,31 @@ public class MetaDataRegressionTest extends BaseTestCase {
     }
 
     /**
+     * Tests *text column type name bug
+     *
+     * @throws Exception
+     *             if any errors occur
+     */
+    public void testColumnTypeNameOfText() throws Exception {
+        try {
+            this.stmt.execute("DROP TABLE IF EXISTS textVarcharTest");
+            this.stmt.execute("CREATE TABLE textVarcharTest (FieldName1 TINYTEXT,  FieldName2 TEXT, FieldName3 MEDIUMTEXT, FieldName4 LONGTEXT);");
+
+            String query = "SELECT FieldName1, FieldName2, FieldName3, FieldName4 FROM textVarcharTest";
+            this.rs = this.stmt.executeQuery(query);
+
+            ResultSetMetaData rsmeta = this.rs.getMetaData();
+
+            assertTrue(rsmeta.getColumnTypeName(1).equalsIgnoreCase("TINYTEXT"));
+            assertTrue(rsmeta.getColumnTypeName(2).equalsIgnoreCase("TEXT"));
+            assertTrue(rsmeta.getColumnTypeName(3).equalsIgnoreCase("MEDIUMTEXT"));
+            assertTrue(rsmeta.getColumnTypeName(4).equalsIgnoreCase("LONGTEXT"));
+        } finally {
+            this.stmt.execute("DROP TABLE IF EXISTS textVarcharTest");
+        }
+    }
+
+    /**
      * Tests fix for BUG#1673, where DatabaseMetaData.getColumns() is not
      * returning correct column ordinal info for non '%' column name patterns.
      * 


### PR DESCRIPTION
Non-binary blob returns `TEXT`, the other three types should also do this.
Found this issue, when using JOOQ which relies on the method to generate corresponding java types.