### PR TITLE
LoadBalancedConnectionProxy.getGlobalBlacklist bug fix

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/LoadBalancedConnectionProxy.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/LoadBalancedConnectionProxy.java
@@ -728,7 +728,7 @@ public class LoadBalancedConnectionProxy extends MultiHostConnectionProxy implem
         Set<String> keys = blacklistClone.keySet();
 
         // We're only interested in blacklisted hosts that are in the hostList
-        keys.retainAll(this.hostsList.stream().map(hi -> hi.getHost()).collect(Collectors.toList()));
+        keys.retainAll(this.hostsList.stream().map(hi -> hi.getHostPortPair()).collect(Collectors.toList()));
 
         // Don't need to synchronize here as we using a local copy
         for (Iterator<String> i = keys.iterator(); i.hasNext();) {


### PR DESCRIPTION
LoadBalancedConnectionProxy.getGlobalBlacklist incorrectly used hostsList->getHost, but globalBlacklist consists of host:port strings. As result getGlobalBlacklist always returns empty map