### PR TITLE
Setting logSlowQueries should not automatically enable profileSQL for all queries (#94101)

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
@@ -254,7 +254,7 @@ public class StatementImpl implements JdbcStatement {
             setFetchSize(defaultFetchSize);
         }
 
-        boolean profiling = this.profileSQL || this.useUsageAdvisor || this.logSlowQueries;
+        boolean profiling = this.profileSQL || this.useUsageAdvisor;
 
         if (profiling) {
             this.pointOfOrigin = LogUtils.findCallingClassAndMethod(new Throwable());


### PR DESCRIPTION
Hello fellow developers!

I was analysing a couple of flame graphs with the setting logSlowQueries enabled and saw the following method was very frequently called: **LogUtils.findCallingClassAndMethod**

When using a lot of short queries the stack trace gathering accounted for 30-40% of the samples.

The methods in question are:
1.) com.mysql.cj.protocol.a.NativeProtocol.sendQueryPacket(Query, NativePacketPayload, int, boolean, String, ColumnDefinition, GetProfilerEventHandlerInstanceFunction, ProtocolEntityFactory<T, NativePacketPayload>)
2.) com.mysql.cj.jdbc.StatementImpl.StatementImpl(JdbcConnection, String)

I looked around and in the other places I've found where profileSQL is used. It is handled separate from logSlowQueries. It seems like in the two places it was just left there out of convenience.

In my humble option should findCallingClassAndMethod should only be called if profiling/usageAdvisor is enabled or if logSlowQueries is enabled and a slow query is detected.

I provided a pull request that would change the following:

In 1.) i remove logSlowQueries from the boolean expression since it is not used later on anyway.
In 2.) I removed logSlowQueries from the outer if to run only if both are enabled, and call findCallingClassAndMethod only once.

Kind regards 
Florian


<img width="500" alt="flame_html" src="https://user-images.githubusercontent.com/1190368/51844767-542d0500-2316-11e9-8499-e17a290d90e5.png">