### PR TITLE
Fix for #93590 - ignore javax.net.ssl.SSLException: closing inbound before receiving peer's close_notify on java11+

### DIFF
--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeProtocol.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeProtocol.java
@@ -1322,7 +1322,13 @@ public class NativeProtocol extends AbstractProtocol<NativePacketPayload> implem
                     }
                 }
             } catch (IOException ioEx) {
-                this.log.logWarn("Caught while disconnecting...", ioEx);
+                // See https://bugs.mysql.com/bug.php?id=93590
+                // Inspired by: https://github.com/netty/netty/issues/1340
+                // This is a java11 "bug", so don't log it
+                String msg = ioEx.getMessage();
+                if (msg == null || !msg.contains("closing inbound before receiving peer's close_notify")) {
+                    this.log.logWarn("Caught while disconnecting...", ioEx);
+                }
             }
 
             this.packetSequence = -1;


### PR DESCRIPTION
This is inspired by netty: https://github.com/netty/netty/blob/41b02368153af86b1ddb19020ebf5e4f7c69aecd/handler/src/main/java/io/netty/handler/ssl/SslHandler.java#L1779

They ignore/suppress this exception.

Log files are getting flooded with:

```
Wed Apr 03 13:47:20 PDT 2019 WARN: Caught while disconnecting...

EXCEPTION STACK TRACE:



** BEGIN NESTED EXCEPTION **

javax.net.ssl.SSLException
MESSAGE: closing inbound before receiving peer's close_notify

STACKTRACE:

javax.net.ssl.SSLException: closing inbound before receiving peer's close_notify
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:129)
	at java.base/sun.security.ssl.Alert.createSSLException(Alert.java:117)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:308)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:264)
	at java.base/sun.security.ssl.TransportContext.fatal(TransportContext.java:255)
	at java.base/sun.security.ssl.SSLSocketImpl.shutdownInput(SSLSocketImpl.java:645)
	at java.base/sun.security.ssl.SSLSocketImpl.shutdownInput(SSLSocketImpl.java:624)
	at com.mysql.cj.protocol.a.NativeProtocol.quit(NativeProtocol.java:1319)
	at com.mysql.cj.NativeSession.quit(NativeSession.java:182)
	at com.mysql.cj.jdbc.ConnectionImpl.realClose(ConnectionImpl.java:1750)
	at com.mysql.cj.jdbc.ConnectionImpl.close(ConnectionImpl.java:720)
	at com.zaxxer.hikari.pool.PoolBase.quietlyCloseConnection(PoolBase.java:135)
	at com.zaxxer.hikari.pool.HikariPool.lambda$closeConnection$1(HikariPool.java:441)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```