### PR TITLE
Fix for #93444 - improve setObject behavior for LocalDate, LocalDateTime and LocalTime

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/QueryBindings.java
+++ b/src/main/core-api/java/com/mysql/cj/QueryBindings.java
@@ -38,6 +38,7 @@ import java.sql.Date;
 import java.sql.NClob;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Calendar;
 
 import com.mysql.cj.protocol.ColumnDefinition;
@@ -159,6 +160,8 @@ public interface QueryBindings<T extends BindValue> {
     void setInt(int parameterIndex, int x);
 
     // int getInt(int parameterIndex);
+
+    void setLocalDateTime(int parameterIndex, LocalDateTime x, MysqlType targetMysqlType);
 
     void setLong(int parameterIndex, long x);
 

--- a/src/main/core-impl/java/com/mysql/cj/ClientPreparedQueryBindings.java
+++ b/src/main/core-impl/java/com/mysql/cj/ClientPreparedQueryBindings.java
@@ -47,6 +47,7 @@ import java.sql.NClob;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.Calendar;
 
 import com.mysql.cj.conf.PropertyKey;
@@ -438,6 +439,27 @@ public class ClientPreparedQueryBindings extends AbstractQueryBindings<ClientPre
     @Override
     public void setInt(int parameterIndex, int x) {
         setValue(parameterIndex, String.valueOf(x), MysqlType.INT);
+    }
+
+    @Override
+    public void setLocalDateTime(int parameterIndex, LocalDateTime x, MysqlType targetMysqlType) {
+        if (targetMysqlType == MysqlType.DATE) {
+            setValue(parameterIndex, "'" + x.toLocalDate() + "'", MysqlType.DATE);
+        } else {
+            x = adjustNanos(x, parameterIndex);
+
+            switch (targetMysqlType) {
+                case TIME:
+                    setValue(parameterIndex, "'" + x.toLocalTime() + "'", targetMysqlType);
+                    break;
+                case DATETIME:
+                case TIMESTAMP:
+                    setValue(parameterIndex, "'" + x.toLocalDate() + " " + x.toLocalTime() + "'", targetMysqlType);
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
     @Override

--- a/src/test/java/testsuite/simple/StatementsTest.java
+++ b/src/test/java/testsuite/simple/StatementsTest.java
@@ -47,6 +47,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLType;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -59,6 +60,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.util.Properties;
+import java.util.TimeZone;
 import java.util.concurrent.Callable;
 
 import com.mysql.cj.CharsetMapping;
@@ -3704,5 +3706,97 @@ public class StatementsTest extends BaseTestCase {
                 return null;
             }
         });
+    }
+
+    public void testSetObjectLocalDateInDifferentTimezone() throws Exception {
+        Properties props = new Properties();
+        for (int i = 0; i < 2; i++) {
+            setObjectInDifferentTimezone("DATE", LocalDate.of(2019, 12, 31), null, "2019-12-31", props);
+            setObjectInDifferentTimezone("DATE", LocalDate.of(2019, 12, 31), MysqlType.DATE, "2019-12-31", props);
+            setObjectInDifferentTimezone("DATETIME", LocalDate.of(2019, 12, 31), null, "2019-12-31T00:00:00", props);
+            setObjectInDifferentTimezone("DATETIME", LocalDate.of(2019, 12, 31), MysqlType.DATETIME, "2019-12-31T00:00:00", props);
+            setObjectInDifferentTimezone("TIMESTAMP", LocalDate.of(2019, 12, 31), null, "2019-12-31T00:00:00", props);
+            setObjectInDifferentTimezone("TIMESTAMP", LocalDate.of(2019, 12, 31), MysqlType.TIMESTAMP, "2019-12-31T00:00:00", props);
+            // setObjectInDifferentTimezone("YEAR", LocalDate.of(2019, 1, 1), null, "2019", props);
+            setObjectInDifferentTimezone("YEAR", LocalDate.of(2019, 1, 1), MysqlType.YEAR, "2019", props);
+            // setObjectInDifferentTimezone("TIME", LocalDate.of(2019, 12, 31), null, "00:00:00", props);
+            // setObjectInDifferentTimezone("TIME", LocalDate.of(2019, 12, 31), MysqlType.TIME, "00:00:00", props);
+
+            props.put(PropertyKey.useServerPrepStmts.getKeyName(), "true");
+        }
+    }
+
+    public void testSetObjectLocalDateTimeInDifferentTimezone() throws Exception {
+        // truncation/rounding is tested in StatementRegressionTest#testBug77449
+        Properties props = new Properties();
+        for (int i = 0; i < 2; i++) {
+            setObjectInDifferentTimezone("DATETIME(6)", LocalDateTime.of(2019, 12, 31, 11, 22, 33, 123456000), null, "2019-12-31T11:22:33.123456", props);
+            setObjectInDifferentTimezone("DATETIME(6)", LocalDateTime.of(2019, 12, 31, 11, 22, 33, 123456000), MysqlType.DATETIME, "2019-12-31T11:22:33.123456",
+                    props);
+            setObjectInDifferentTimezone("TIMESTAMP(6)", LocalDateTime.of(2019, 12, 31, 11, 22, 33, 123456000), null, "2019-12-31T11:22:33.123456", props);
+            setObjectInDifferentTimezone("TIMESTAMP(6)", LocalDateTime.of(2019, 12, 31, 11, 22, 33, 123456000), MysqlType.TIMESTAMP,
+                    "2019-12-31T11:22:33.123456", props);
+            setObjectInDifferentTimezone("DATE", LocalDateTime.of(2019, 12, 31, 11, 22, 33, 123456000), null, "2019-12-31", props);
+            setObjectInDifferentTimezone("DATE", LocalDateTime.of(2019, 12, 31, 11, 22, 33, 123456000), MysqlType.DATE, "2019-12-31", props);
+            // setObjectInDifferentTimezone("YEAR", LocalDateTime.of(2019, 1, 1, 11, 22, 33, 123456000), null, "2019", props);
+            setObjectInDifferentTimezone("YEAR", LocalDateTime.of(2019, 1, 1, 11, 22, 33, 123456000), MysqlType.YEAR, "2019", props);
+            setObjectInDifferentTimezone("TIME(6)", LocalDateTime.of(2019, 12, 31, 11, 22, 33, 123456000), null, "11:22:33.123456", props);
+            setObjectInDifferentTimezone("TIME(6)", LocalDateTime.of(2019, 12, 31, 11, 22, 33, 123456000), MysqlType.TIME, "11:22:33.123456", props);
+
+            props.put(PropertyKey.useServerPrepStmts.getKeyName(), "true");
+        }
+    }
+
+    public void testSetObjectLocalTimeInDifferentTimezone() throws Exception {
+        // truncation/rounding is tested in StatementRegressionTest#testBug77449
+        Properties props = new Properties();
+        for (int i = 0; i < 2; i++) {
+            setObjectInDifferentTimezone("TIME(6)", LocalTime.of(11, 22, 33, 123456000), null, "11:22:33.123456", props);
+            setObjectInDifferentTimezone("TIME(6)", LocalTime.of(11, 22, 33, 123456000), MysqlType.TIME, "11:22:33.123456", props);
+            // setObjectInDifferentTimezone("DATE", LocalTime.of(11, 22, 33, 123456000), null, "1970-01-01", props);
+            setObjectInDifferentTimezone("DATE", LocalTime.of(11, 22, 33, 123456000), MysqlType.DATE, "1970-01-01", props);
+            // setObjectInDifferentTimezone("DATETIME(6)", LocalTime.of(11, 22, 33, 123456000), null, "1970-01-01T11:22:33.123456", props);
+            setObjectInDifferentTimezone("DATETIME(6)", LocalTime.of(11, 22, 33, 123456000), MysqlType.TIMESTAMP, "1970-01-01T11:22:33.123456", props);
+            // setObjectInDifferentTimezone("TIMESTAMP(6)", LocalTime.of(11, 22, 33, 123456000), null, "1970-01-01T11:22:33.123456", props);
+            setObjectInDifferentTimezone("TIMESTAMP(6)", LocalTime.of(11, 22, 33, 123456000), MysqlType.TIMESTAMP, "1970-01-01T11:22:33.123456", props);
+            // setObjectInDifferentTimezone("YEAR", LocalTime.of(11, 22, 33, 123456000), null, "1970", props);
+            setObjectInDifferentTimezone("YEAR", LocalTime.of(11, 22, 33, 123456000), MysqlType.YEAR, "1970", props);
+
+            props.put(PropertyKey.useServerPrepStmts.getKeyName(), "true");
+        }
+    }
+
+    private void setObjectInDifferentTimezone(String columnType, Object parameter, SQLType targetSqlType, String expectedValue, Properties props)
+            throws SQLException {
+        if (props == null) {
+            props = new Properties();
+        }
+        final String tableName = "testSetObjectDateAndTime";
+        final TimeZone origTz = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("GMT+23:50"));
+            createTable(tableName, "(id INT, d " + columnType + ")");
+            try (Connection testConn = getConnectionWithProps(props)) {
+                try (PreparedStatement localPstmt = testConn.prepareStatement("INSERT INTO " + tableName + " VALUES (?, ?)")) {
+                    localPstmt.setInt(1, 1);
+                    if (targetSqlType == null) {
+                        localPstmt.setObject(2, parameter);
+                    } else {
+                        localPstmt.setObject(2, parameter, targetSqlType);
+                    }
+                    assertEquals(1, localPstmt.executeUpdate());
+                }
+                try (Statement localStmt = testConn.createStatement();
+                        ResultSet localRs = localStmt.executeQuery("SELECT COUNT(*) FROM " + tableName + " WHERE id = 1 AND d = '" + expectedValue + "'")) {
+                    assertTrue(localRs.next());
+                    assertEquals(
+                            String.format("column type: '%s', parameter: '%s', sqlType: '%s', properties: '%s'.", columnType, parameter, targetSqlType, props),
+                            1, localRs.getInt(1));
+                }
+            }
+            dropTable(tableName);
+        } finally {
+            TimeZone.setDefault(origTz);
+        }
     }
 }


### PR DESCRIPTION
This PR is an attempt to fix [#93444](https://bugs.mysql.com/bug.php?id=93444). i.e.

- Inserted `LocalDate`, `LocalDateTime` and `LocalTime` values are altered when there is timezone difference between server and client.

The basic idea is to eliminate involvement of the legacy date/time classes (e.g. `java.sql.Timestamp`, `java.util.Calendar`) during the process.

Some notes:

- On my environment, there is no new test failure caused by this change.
- Commented-out lines in `StatementTest` are seemingly unsupported conversions. I left them for you to confirm that they all are expected.
- I have sent my signed OCA a few days ago.
- I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.

If there is anything you want me to change or clarify, please let me know.