### PR TITLE
Introduced parameter to skip sending client certificates in TLS

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
@@ -731,7 +731,10 @@ public class PropertyDefinitions {
                         Messages.getString("ConnectionProperties.enableEscapeProcessing"), "6.0.1", CATEGORY_PERFORMANCE, Integer.MIN_VALUE),
 
                 new StringPropertyDefinition(PropertyKey.serverAffinityOrder, DEFAULT_VALUE_NULL_STRING, RUNTIME_NOT_MODIFIABLE,
-                        Messages.getString("ConnectionProperties.serverAffinityOrder"), "8.0.8", CATEGORY_HA, Integer.MIN_VALUE) };
+                        Messages.getString("ConnectionProperties.serverAffinityOrder"), "8.0.8", CATEGORY_HA, Integer.MIN_VALUE),
+
+                new BooleanPropertyDefinition(PropertyKey.clientAuthenticationRequired, DEFAULT_VALUE_TRUE, RUNTIME_MODIFIABLE,
+                        Messages.getString("ConnectionProperties.clientAuthenticationRequired"), "8.0.8", CATEGORY_SECURITY, Integer.MIN_VALUE) };
 
         HashMap<PropertyKey, PropertyDefinition<?>> propertyKeyToPropertyDefinitionMap = new HashMap<>();
         for (PropertyDefinition<?> pdef : pdefs) {

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
@@ -87,6 +87,7 @@ public enum PropertyKey {
     clientCertificateKeyStorePassword("clientCertificateKeyStorePassword", true), //
     clientCertificateKeyStoreType("clientCertificateKeyStoreType", true), //
     clientCertificateKeyStoreUrl("clientCertificateKeyStoreUrl", true), //
+    clientAuthenticationRequired("clientAuthenticationRequired", true), //
     clientInfoProvider("clientInfoProvider", true), //
     clobberStreamingResults("clobberStreamingResults", true), //
     clobCharacterEncoding("clobCharacterEncoding", true), //

--- a/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
+++ b/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
@@ -260,6 +260,10 @@ public class ExportControlled {
             }
         }
 
+        if (!propertySet.getBooleanProperty(PropertyKey.clientAuthenticationRequired).getValue()) {
+            return new KeyStoreConf(null, null, keyStoreType);
+        }
+
         return new KeyStoreConf(keyStoreUrl, keyStorePassword, keyStoreType);
     }
 


### PR DESCRIPTION
Driver currently automatically adds the keystore to the TLS configuration if present. We have a scenario where we use mutual TLS for connections other than to our database, where server authenticated TLS is required, but not client authentication. The database is not configured to verify the client certs, so TLS connections fail. 

This change introduces a parameter that can be used to skip adding the client credentials. It is coded to be backward compatible with the current behavior.