### PR TITLE
clamp dates with invalid years to 0

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/result/SqlDateValueFactory.java
+++ b/src/main/core-impl/java/com/mysql/cj/result/SqlDateValueFactory.java
@@ -76,6 +76,9 @@ public class SqlDateValueFactory extends AbstractDateTimeValueFactory<Date> {
                 if (idate.isZero()) {
                     throw new DataReadException(Messages.getString("ResultSet.InvalidZeroDate"));
                 }
+                if (idate.getYear() <= 0) {
+                    throw new DataReadException(Messages.getString("ResultSet.InvalidYear", new Object[] { idate.getYear() }));
+                }
 
                 this.cal.clear();
                 this.cal.set(idate.getYear(), idate.getMonth() - 1, idate.getDay());

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlTextValueDecoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlTextValueDecoder.java
@@ -67,6 +67,9 @@ public class MysqlTextValueDecoder implements ValueDecoder {
     /** Max string length of a signed long = 9223372036854775807 (19+1 for minus sign) */
     public static final int MAX_SIGNED_LONG_LEN = 20;
 
+    /** Min supported year when parsing DATE, DATETIME and TIMESTAMP columns. This is more lenient than the ranges stated in the MySQL documentation. */
+    private static final int DATE_MIN_VALID_YEAR = 1;
+
     public <T> T decodeDate(byte[] bytes, int offset, int length, ValueFactory<T> vf) {
         return vf.createFromDate(getDate(bytes, offset, length));
     }
@@ -256,6 +259,9 @@ public class MysqlTextValueDecoder implements ValueDecoder {
             throw new DataReadException(Messages.getString("ResultSet.InvalidLengthForType", new Object[] { length, "DATE" }));
         }
         int year = getInt(bytes, offset, offset + 4);
+        if (year < DATE_MIN_VALID_YEAR) {
+            return new InternalDate();
+        }
         int month = getInt(bytes, offset + 5, offset + 7);
         int day = getInt(bytes, offset + 8, offset + 10);
         return new InternalDate(year, month, day);
@@ -353,6 +359,9 @@ public class MysqlTextValueDecoder implements ValueDecoder {
         }
 
         int year = getInt(bytes, offset, offset + 4);
+        if (year < DATE_MIN_VALID_YEAR) {
+            return new InternalTimestamp();
+        }
         int month = getInt(bytes, offset + 5, offset + 7);
         int day = getInt(bytes, offset + 8, offset + 10);
         int hours = getInt(bytes, offset + 11, offset + 13);

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -423,6 +423,7 @@ ResultSet.UnableToConvertString=Cannot convert string ''{0}'' to {1} value
 ResultSet.UnknownSourceType=Cannot decode value of unknown source type
 ResultSet.InvalidTimeValue=The value ''{0}'' is an invalid TIME value. JDBC Time objects represent a wall-clock time and not a duration as MySQL treats them. If you are treating this type as a duration, consider retrieving this value as a string and dealing with it according to your requirements.
 ResultSet.InvalidZeroDate=Zero date value prohibited
+ResultSet.InvalidYear=The date ''{0}'' is out of the supported range.
 
 #
 # Usage advisor messages for ResultSets


### PR DESCRIPTION
Asp er the MySQL documentation DATE and DATETIME only support ranges from
'1000-01-01 00:00:00' to '9999-12-31 23:59:59', and TIMESTAMP from
'1970-01-01 00:00:01.000000' to '2038-01-19 03:14:07.999999'. Values outside
those ranges are not guaranteed to work. Additionally it mentions that invalid
values are converted to their appropriate zero value.

The patch converts dates that lead to an exception right now to their zero
value. This is more lenient than what the ranges given in the documentation.
The behaviour set through zeroDateTimeBehavior applies to these zero values.

This fixes Bug#94872.