### PR TITLE
reduce always fail prepare request in batch update

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/NativeSession.java
+++ b/src/main/core-impl/java/com/mysql/cj/NativeSession.java
@@ -126,6 +126,9 @@ public class NativeSession extends CoreSession implements Serializable {
     /** Has this session been closed? */
     private boolean isClosed = true;
 
+    /** Does this session temp enable MultiQueries? */
+    private boolean isTempMultiQueriesEnable = false;
+
     /** Why was this session implicitly closed, if known? (for diagnostics) */
     private Throwable forceClosedReason;
 
@@ -220,11 +223,13 @@ public class NativeSession extends CoreSession implements Serializable {
 
     public void enableMultiQueries() {
         sendCommand(this.commandBuilder.buildComSetOption(((NativeProtocol) this.protocol).getSharedSendPacket(), 0), false, 0);
+        this.isTempMultiQueriesEnable = true;
         ((NativeServerSession) getServerSession()).preserveOldTransactionState();
     }
 
     public void disableMultiQueries() {
         sendCommand(this.commandBuilder.buildComSetOption(((NativeProtocol) this.protocol).getSharedSendPacket(), 1), false, 0);
+        this.isTempMultiQueriesEnable = false;
         ((NativeServerSession) getServerSession()).preserveOldTransactionState();
     }
 
@@ -1199,6 +1204,10 @@ public class NativeSession extends CoreSession implements Serializable {
 
     public boolean isClosed() {
         return this.isClosed;
+    }
+
+    public boolean isTempMultiQueriesEnable() {
+        return this.isTempMultiQueriesEnable;
     }
 
     public void checkClosed() {

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
@@ -504,7 +504,7 @@ public class ConnectionImpl implements JdbcConnection, SessionEventListener, Ser
             return false;
         }
 
-        boolean allowMultiQueries = this.propertySet.getBooleanProperty(PropertyKey.allowMultiQueries).getValue();
+        boolean allowMultiQueries = this.propertySet.getBooleanProperty(PropertyKey.allowMultiQueries).getValue() || this.getSession().isTempMultiQueriesEnable();
 
         if (this.cachePrepStmts.getValue()) {
             synchronized (this.serverSideStatementCheckCache) {


### PR DESCRIPTION
let canHandleAsServerPreparedStatement take care multi-queries from batch rewrite.

- add new flag in NativeServerSession 
- control this flag by enableMultiQueries/disableMultiQueries
- canHandleAsServerPreparedStatement can check this new flag plus allowMultiQueries

This fixes [Bug#96623
](https://bugs.mysql.com/bug.php?id=96623)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mysql/mysql-connector-j/42)
<!-- Reviewable:end -->
