### PR TITLE
Expose elapsed time for query interceptor to avoid hacky thread local implementations

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/Query.java
+++ b/src/main/core-api/java/com/mysql/cj/Query.java
@@ -89,6 +89,16 @@ public interface Query {
 
     void setTimeoutInMillis(int timeoutInMillis);
 
+    void setElapsedTime(long elapsedTime);
+
+    /**
+     * Returns the elapsed time for the server to process the query.
+     * profileQueries must be enabled or <code>-1</code> will be returned.
+     *
+     * @return the elapsed time or <code>-1</code>.
+     */
+    long getElapsedTime();
+
     CancelQueryTask startQueryTimer(Query stmtToCancel, int timeout);
 
     AtomicBoolean getStatementExecuting();

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
@@ -726,6 +726,9 @@ public class PropertyDefinitions {
                 new BooleanPropertyDefinition(PropertyKey.autoGenerateTestcaseScript, DEFAULT_VALUE_FALSE, RUNTIME_MODIFIABLE,
                         Messages.getString("ConnectionProperties.autoGenerateTestcaseScript"), "3.1.9", CATEGORY_DEBUGING_PROFILING, 18),
 
+                new BooleanPropertyDefinition(PropertyKey.profileQueries, DEFAULT_VALUE_FALSE, RUNTIME_MODIFIABLE,
+                                              Messages.getString("ConnectionProperties.profileQueries"), "8.0.18", CATEGORY_DEBUGING_PROFILING, 19),
+
                 //
                 // CATEGORY_EXCEPTIONS
                 //

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
@@ -727,7 +727,7 @@ public class PropertyDefinitions {
                         Messages.getString("ConnectionProperties.autoGenerateTestcaseScript"), "3.1.9", CATEGORY_DEBUGING_PROFILING, 18),
 
                 new BooleanPropertyDefinition(PropertyKey.profileQueries, DEFAULT_VALUE_FALSE, RUNTIME_MODIFIABLE,
-                                              Messages.getString("ConnectionProperties.profileQueries"), "8.0.18", CATEGORY_DEBUGING_PROFILING, 19),
+                                              Messages.getString("ConnectionProperties.profileQueries"), "8.0.19", CATEGORY_DEBUGING_PROFILING, 19),
 
                 //
                 // CATEGORY_EXCEPTIONS

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
@@ -172,6 +172,7 @@ public enum PropertyKey {
     processEscapeCodesForPrepStmts("processEscapeCodesForPrepStmts", true), //
     profilerEventHandler("profilerEventHandler", true), //
     profileSQL("profileSQL", true), //
+    profileQueries("profileQueries", true), //
     propertiesTransform("propertiesTransform", true), //
     queriesBeforeRetryMaster("queriesBeforeRetryMaster", true), //
     queryInterceptors("queryInterceptors", true), //

--- a/src/main/core-impl/java/com/mysql/cj/AbstractQuery.java
+++ b/src/main/core-impl/java/com/mysql/cj/AbstractQuery.java
@@ -87,6 +87,9 @@ public abstract class AbstractQuery implements Query {
     /** Has clearWarnings() been called? */
     protected boolean clearWarningsCalled = false;
 
+    /** Elapsed time of the execution */
+    private long elapsedTime = -1;
+
     public AbstractQuery(NativeSession sess) {
         statementCounter++;
         this.session = sess;
@@ -102,6 +105,16 @@ public abstract class AbstractQuery implements Query {
     @Override
     public void setCancelStatus(CancelStatus cs) {
         this.cancelStatus = cs;
+    }
+
+    @Override
+    public long getElapsedTime() {
+        return elapsedTime;
+    }
+
+    @Override
+    public void setElapsedTime(long elapsedTime) {
+        this.elapsedTime = elapsedTime;
     }
 
     @Override

--- a/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
+++ b/src/main/resources/com/mysql/cj/LocalizedErrorMessages.properties
@@ -804,6 +804,7 @@ ConnectionProperties.prepStmtCacheSqlLimit=If prepared statement caching is enab
 ConnectionProperties.processEscapeCodesForPrepStmts=Should the driver process escape codes in queries that are prepared? Default escape processing behavior in non-prepared statements must be defined with the property 'enableEscapeProcessing'.
 ConnectionProperties.profilerEventHandler=Name of a class that implements the interface com.mysql.cj.log.ProfilerEventHandler that will be used to handle profiling/tracing events.
 ConnectionProperties.profileSQL=Trace queries and their execution/fetch times to the configured 'profilerEventHandler'
+ConnectionProperties.profileQueries=Enables support for 'Query.getElapsedTime() ' in postProcess to all configured QueryInterceptors.
 ConnectionProperties.connectionPropertiesTransform=An implementation of com.mysql.cj.conf.ConnectionPropertiesTransform that the driver will use to modify URL properties passed to the driver before attempting a connection
 ConnectionProperties.queriesBeforeRetryMaster=Number of queries to issue before falling back to the primary host when failed over (when using multi-host failover). Whichever condition is met first, 'queriesBeforeRetryMaster' or 'secondsBeforeRetryMaster' will cause an attempt to be made to reconnect to the primary host. Setting both properties to 0 disables the automatic fall back to the primary host at transaction boundaries. Defaults to 50.
 ConnectionProperties.reconnectAtTxEnd=If autoReconnect is set to true, should the driver attempt reconnections at the end of every transaction?

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
@@ -2238,6 +2238,18 @@ public class StatementImpl implements JdbcStatement {
     }
 
     @Override
+    public long getElapsedTime() {
+        return this.query.getElapsedTime();
+    }
+
+    @Override
+    public void setElapsedTime(long elapsedTime) {
+        if (this.query != null) {
+            this.query.setElapsedTime(elapsedTime);
+        }
+    }
+
+    @Override
     public AtomicBoolean getStatementExecuting() {
         return this.query.getStatementExecuting();
     }


### PR DESCRIPTION
Add option profileQueries to allow Query.getElapsedTime() in all configured interceptors. This allows profiling query timings without ThreadLocal. 

Collaboration with Johnathan Crawford.