### PR TITLE
Allow '3.' formatted numbers

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/result/AbstractNumericValueFactory.java
+++ b/src/main/core-impl/java/com/mysql/cj/result/AbstractNumericValueFactory.java
@@ -52,7 +52,7 @@ public abstract class AbstractNumericValueFactory<T> extends DefaultValueFactory
         String s = StringUtils.toString(bytes, offset, length, f.getEncoding());
         byte[] newBytes = s.getBytes();
 
-        if (s.contains("e") || s.contains("E") || s.matches("-?(\\d+)?\\.\\d+")) {
+        if (s.contains("e") || s.contains("E") || s.matches("-?(\\d+)?\\.(\\d+)?")) {
             // floating point
             return createFromDouble(MysqlTextValueDecoder.getDouble(newBytes, 0, newBytes.length));
         } else if (s.matches("-?\\d+")) {


### PR DESCRIPTION
Given a stored value of `3.` in a `VARCHAR` column, a `DataConversionException` is thrown because the regex doesn't match. 

Java's `BigDecimal`, and MySQL's `DECIMAL` and `VARCHAR` columns all handle this case correctly.