### PR TITLE
Allow empty keyStore file for keyStoreTypes that do not require files

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
+++ b/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
@@ -522,17 +522,16 @@ public class ExportControlled {
                     }
                 }
             }
-        }
-        else {
+        } else {
+            // Some KeyManagers do not require a keystore to be in a file, so see if there's a functional KeyManager even though
+            // clientCertificateKeyStoreUrl was empty.
             try{
                 if (!StringUtils.isNullOrEmpty(clientCertificateKeyStoreType)) {
-                    KeyStore clientKeyStore = KeyStore.getInstance(clientCertificateKeyStoreType);
-                    clientKeyStore.load(null);
-                    kmf.init(null);
                     kms = kmf.getKeyManagers();
                 }
-            } catch (Exception e) {
-                System.out.println(e);
+            } catch (IllegalStateException ise) {
+                throw ExceptionFactory.createException(SSLParamsException.class, "No keystore file/URL given, and client certificate key store of type " + clientCertificateKeyStoreType + " is not initialized.",
+                        ise, exceptionInterceptor);
             }
         }
 

--- a/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
+++ b/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
@@ -523,6 +523,18 @@ public class ExportControlled {
                 }
             }
         }
+        else {
+            try{
+                if (!StringUtils.isNullOrEmpty(clientCertificateKeyStoreType)) {
+                    KeyStore clientKeyStore = KeyStore.getInstance(clientCertificateKeyStoreType);
+                    clientKeyStore.load(null);
+                    kmf.init(null);
+                    kms = kmf.getKeyManagers();
+                }
+            } catch (Exception e) {
+                System.out.println(e);
+            }
+        }
 
         InputStream trustStoreIS = null;
         try {


### PR DESCRIPTION
This PR adds simple handling for an empty keyStore file, for use with KeyStoreManagers that do not require a defined keystore.

One such example is SPIFFE with java-spiffe: https://github.com/spiffe/java-spiffe.