### PR TITLE
Support Windows time zone 'Coordinated Universal Time'

### DIFF
--- a/src/main/resources/com/mysql/cj/util/TimeZoneMapping.properties
+++ b/src/main/resources/com/mysql/cj/util/TimeZoneMapping.properties
@@ -66,6 +66,7 @@ Chatham\ Islands\ Daylight\ Time=Pacific/Chatham
 Chatham\ Islands\ Standard\ Time=Pacific/Chatham
 China\ Daylight\ Time=Asia/Shanghai
 China\ Standard\ Time=Asia/Shanghai
+Coordinated\ Universal\ Time=Etc/UTC
 Cuba\ Daylight\ Time=America/Havana
 Cuba\ Standard\ Time=America/Havana
 Dateline\ Daylight\ Time=Etc/GMT+12


### PR DESCRIPTION
Add in file `TimeZoneMapping.properties` the time zone named `Coordinated Universal Time` which is available on Windows servers.
That is for example the case when we automatically provision Mysql DBMS from Azure Kubernetes Service using Open Service Broker (for Azure) : a Mysql server is provisioned on a Windows server having the system time zone defined as `Coordinated Universal Time`.
But as this time zone is not recognized by Mysql driver, our Java application fail and does not start. This is very annoying because all our applications are automatically deployed via a CD pipeline (and the provisioning of Mysql DBMS is one step of this pipeline).