### PR TITLE
Check SubjectAlternativeName for TLS instead of commonName

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
+++ b/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
@@ -419,10 +419,10 @@ public class ExportControlled {
                         String sanmatch = null;
                         for (final List<?> san : sans) {
                             Integer sanType = (Integer) san.get(0);
-                            String sanVal = (String) san.get(1);
                             // 2 = dNSName
                             // 7 = iPAddress
                             if ((sanType == 2) || ( sanType == 7)) {
+                                String sanVal = (String) san.get(1);
                                 if (this.hostName.equalsIgnoreCase(sanVal)) {
                                     sanmatch = sanVal;
                                     break;


### PR DESCRIPTION
Related:
* https://tools.ietf.org/html/rfc6125#section-6.4.4
* https://bugs.mysql.com/bug.php?id=93301 Connector/C++
* https://bugs.mysql.com/bug.php?id=68052 libmysqlclient

Fixes:
* https://bugs.mysql.com/bug.php?id=92903

Instead of manually checking SAN and CN it would be nice if there would
be a library which knows how to do this correctly.

I only did very minimal testing.