### PR TITLE
Add maxResultBuffer property.

### DIFF
--- a/src/com/mysql/jdbc/ConnectionProperties.java
+++ b/src/com/mysql/jdbc/ConnectionProperties.java
@@ -1433,4 +1433,8 @@ public interface ConnectionProperties {
     public boolean getEnableEscapeProcessing();
 
     public void setEnableEscapeProcessing(boolean flag);
+
+    public String getMaxResultBuffer();
+
+    public void setMaxResultBuffer(String maxResultBuffer);
 }

--- a/src/com/mysql/jdbc/ConnectionPropertiesImpl.java
+++ b/src/com/mysql/jdbc/ConnectionPropertiesImpl.java
@@ -1340,6 +1340,9 @@ public class ConnectionPropertiesImpl implements Serializable, ConnectionPropert
     private BooleanConnectionProperty enableEscapeProcessing = new BooleanConnectionProperty("enableEscapeProcessing", true,
             Messages.getString("ConnectionProperties.enableEscapeProcessing"), "5.1.37", PERFORMANCE_CATEGORY, Integer.MIN_VALUE);
 
+    private StringConnectionProperty maxResultBuffer = new StringConnectionProperty("maxResultBuffer", null,
+            Messages.getString("ConnectionProperties.maxResultBuffer"), "5.1.50", PERFORMANCE_CATEGORY, Integer.MIN_VALUE);
+
     protected DriverPropertyInfo[] exposeAsDriverPropertyInfoInternal(Properties info, int slotsToReserve) throws SQLException {
         initializeProperties(info);
 
@@ -4991,5 +4994,13 @@ public class ConnectionPropertiesImpl implements Serializable, ConnectionPropert
 
     public void setEnableEscapeProcessing(boolean flag) {
         this.enableEscapeProcessing.setValue(flag);
+    }
+
+    public String getMaxResultBuffer() {
+        return this.maxResultBuffer.getValueAsString();
+    }
+
+    public void setMaxResultBuffer(String maxResultBuffer) {
+        this.maxResultBuffer.setValue(maxResultBuffer);
     }
 }

--- a/src/com/mysql/jdbc/LocalizedErrorMessages.properties
+++ b/src/com/mysql/jdbc/LocalizedErrorMessages.properties
@@ -663,6 +663,7 @@ ConnectionProperties.readOnlyPropagatesToServer=Should the driver issue appropri
 ConnectionProperties.enabledSSLCipherSuites=If "useSSL" is set to "true", overrides the cipher suites enabled for use on the underlying SSL sockets. This may be required when using external JSSE providers or to specify cipher suites compatible with both MySQL server and used JVM.
 ConnectionProperties.enabledTLSProtocols=If "useSSL" is set to "true", overrides the TLS protocols enabled for use on the underlying SSL sockets. This may be used to restrict connections to specific TLS versions.
 ConnectionProperties.enableEscapeProcessing=Sets the default escape processing behavior for Statement objects. The method Statement.setEscapeProcessing() can be used to specify the escape processing behavior for an individual Statement object. Default escape processing behavior in prepared statements must be defined with the property 'processEscapeCodesForPrepStmts'.
+ConnectionProperties.maxResultBuffer=Specifies size of buffer during fetching result set. Can be specified as specified size or percent of heap memory.
 
 # 
 # Error Messages for Connection Properties
@@ -708,3 +709,5 @@ ReplicationConnectionProxy.badValueForReadFromMasterWhenNoSlaves=Bad value ''{0}
 ReplicationConnectionProxy.badValueForReplicationEnableJMX=Bad value ''{0}'' for property "replicationEnableJMX".
 ReplicationConnectionProxy.initializationWithEmptyHostsLists=A replication connection cannot be initialized without master hosts and slave hosts, simultaneously.
 ReplicationConnectionProxy.noHostsInconsistentState=The replication connection is an inconsistent state due to non existing hosts in both its internal hosts lists.
+
+PropertyDefinition.1=The connection property ''{0}'' acceptable patterns are: {1}. The value ''{2}'' is not acceptable.

--- a/src/com/mysql/jdbc/MultiHostMySQLConnection.java
+++ b/src/com/mysql/jdbc/MultiHostMySQLConnection.java
@@ -2495,6 +2495,14 @@ public class MultiHostMySQLConnection implements MySQLConnection {
         getActiveMySQLConnection().setEnableEscapeProcessing(flag);
     }
 
+    public String getMaxResultBuffer() {
+        return getActiveMySQLConnection().getMaxResultBuffer();
+    }
+
+    public void setMaxResultBuffer(String maxResultBuffer) {
+        getActiveMySQLConnection().setMaxResultBuffer(maxResultBuffer);
+    }
+
     public boolean isUseSSLExplicit() {
         return getActiveMySQLConnection().isUseSSLExplicit();
     }

--- a/src/com/mysql/jdbc/counters/Counter.java
+++ b/src/com/mysql/jdbc/counters/Counter.java
@@ -1,0 +1,44 @@
+/*
+  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+
+  The MySQL Connector/J is licensed under the terms of the GPLv2
+  <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most MySQL Connectors.
+  There are special exceptions to the terms and conditions of the GPLv2 as it is applied to
+  this software, see the FOSS License Exception
+  <http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+  This program is free software; you can redistribute it and/or modify it under the terms
+  of the GNU General Public License as published by the Free Software Foundation; version 2
+  of the License.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with this
+  program; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
+  Floor, Boston, MA 02110-1301  USA
+
+ */
+
+package com.mysql.jdbc.counters;
+
+import java.io.IOException;
+
+public interface Counter {
+
+    /**
+     * Increases counter of reading query result bytes
+     * 
+     * @param count
+     *            count of query result bytes
+     * @throws IOException
+     *             throw, when query result is larger then threshold
+     */
+    void increaseCounter(long count) throws IOException;
+
+    /**
+     * Reset counter to 0
+     */
+    void resetCounter();
+}

--- a/src/com/mysql/jdbc/counters/ResultByteBufferCounter.java
+++ b/src/com/mysql/jdbc/counters/ResultByteBufferCounter.java
@@ -1,0 +1,64 @@
+/*
+  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+
+  The MySQL Connector/J is licensed under the terms of the GPLv2
+  <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most MySQL Connectors.
+  There are special exceptions to the terms and conditions of the GPLv2 as it is applied to
+  this software, see the FOSS License Exception
+  <http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+  This program is free software; you can redistribute it and/or modify it under the terms
+  of the GNU General Public License as published by the Free Software Foundation; version 2
+  of the License.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with this
+  program; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
+  Floor, Boston, MA 02110-1301  USA
+
+ */
+
+package com.mysql.jdbc.counters;
+
+
+import java.io.IOException;
+
+/**
+ * Check if query result is not larger then max result buffer size threshold
+ */
+public class ResultByteBufferCounter implements Counter {
+
+    private long resultByteBufferCounter;
+    private long maxResultBuffer;
+
+    public ResultByteBufferCounter(long maxResultBuffer) {
+        this.resultByteBufferCounter = 0;
+        this.maxResultBuffer = maxResultBuffer;
+    }
+
+    public void increaseCounter(long count) throws IOException {
+        if (this.maxResultBuffer != -1) {
+            this.resultByteBufferCounter += count;
+            if (this.resultByteBufferCounter > this.maxResultBuffer) {
+                long counterValue = this.resultByteBufferCounter;
+                resetCounter();
+                throw new IOException(new StringBuilder("Result set exceeded maxResultBuffer limit. Received:  ")
+                    .append(counterValue)
+                    .append("; Current limit: ")
+                    .append(this.maxResultBuffer)
+                    .toString());
+            }
+        }
+    }
+
+    public void resetCounter() {
+        this.resultByteBufferCounter = 0;
+    }
+
+    public long getResultByteBufferCounter() {
+        return this.resultByteBufferCounter;
+    }
+}

--- a/src/com/mysql/jdbc/jdbc2/optional/ConnectionWrapper.java
+++ b/src/com/mysql/jdbc/jdbc2/optional/ConnectionWrapper.java
@@ -2898,6 +2898,14 @@ public class ConnectionWrapper extends WrapperBase implements Connection {
         this.mc.setEnableEscapeProcessing(flag);
     }
 
+    public String getMaxResultBuffer() {
+        return this.mc.getMaxResultBuffer();
+    }
+
+    public void setMaxResultBuffer(String maxResultBuffer) {
+        this.mc.setMaxResultBuffer(maxResultBuffer);
+    }
+
     public boolean isUseSSLExplicit() {
         return this.mc.isUseSSLExplicit();
     }

--- a/src/com/mysql/jdbc/util/ConnectionPropertyMaxResultBufferParser.java
+++ b/src/com/mysql/jdbc/util/ConnectionPropertyMaxResultBufferParser.java
@@ -1,0 +1,251 @@
+/*
+  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+
+  The MySQL Connector/J is licensed under the terms of the GPLv2
+  <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most MySQL Connectors.
+  There are special exceptions to the terms and conditions of the GPLv2 as it is applied to
+  this software, see the FOSS License Exception
+  <http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+  This program is free software; you can redistribute it and/or modify it under the terms
+  of the GNU General Public License as published by the Free Software Foundation; version 2
+  of the License.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with this
+  program; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
+  Floor, Boston, MA 02110-1301  USA
+
+ */
+
+package com.mysql.jdbc.util;
+
+import java.lang.management.ManagementFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import src.com.mysql.jdbc.Messages;
+
+public class ConnectionPropertyMaxResultBufferParser {
+
+    private static final Logger LOGGER = Logger.getLogger(ConnectionPropertyMaxResultBufferParser.class.getName());
+
+    private static final String[] PERCENT_PHRASES = new String[] { "p", "pct", "percent" };
+    public static final String MAX_RESULT_BUFFER_ACCETABLE_PATTERNS = "10 - bytes; 10K - kilobytes; 10M - megabytes; 10G - gigabytes; 10T - terabytes; 10p, 10pct, 10percent - percentage of heap memory";
+
+    /**
+     * Method to parse value of max result buffer size.
+     *
+     * @param value
+     *            string containing size of bytes with optional multiplier (T, G, M or K) or percent
+     *            value to declare max percent of heap memory to use.
+     * @return
+     *         value of max result buffer size.
+     * @throws ParserConfigurationException
+     *             when given value can't be parsed.
+     */
+    public static long parseProperty(String value) throws ParserConfigurationException {
+        long result = -1;
+        if (checkIfValueContainsPercent(value)) {
+            result = parseBytePercentValue(value);
+        } else if (checkIfValueExistsToBeParsed(value)) {
+            result = parseByteValue(value);
+        }
+        result = adjustResultSize(result);
+        return result;
+    }
+
+    /**
+     * Method to check if given value can contain percent declaration of size of max result buffer.
+     *
+     * @param value
+     *            Value to check.
+     * @return
+     *         Result if value contains percent.
+     */
+    private static boolean checkIfValueContainsPercent(String value) {
+        return (value != null) && (getPercentPhraseLengthIfContains(value) != -1);
+    }
+
+    /**
+     * Method to get percent value of max result buffer size dependable on actual free memory. This
+     * method doesn't check other possibilities of value declaration.
+     *
+     * @param value
+     *            string containing percent used to define max result buffer.
+     * @return
+     *         percent value of max result buffer size.
+     * @throws ParserConfigurationException
+     *             Exception when given value can't be parsed.
+     */
+    private static long parseBytePercentValue(String value) throws ParserConfigurationException {
+        long result = -1;
+        int length;
+
+        if (checkIfValueExistsToBeParsed(value)) {
+            length = getPercentPhraseLengthIfContains(value);
+
+            if (length == -1) {
+                throw new ParserConfigurationException(
+                        Messages.getString("PropertyDefinition.1", new Object[] { "maxResultBuffer", MAX_RESULT_BUFFER_ACCETABLE_PATTERNS, value }));
+            }
+
+            result = calculatePercentOfMemory(value, length);
+        }
+        return result;
+    }
+
+    /**
+     * Method to get length of percent phrase existing in given string, only if one of phrases exist
+     * on the length of string.
+     *
+     * @param valueToCheck
+     *            String which is gonna be checked if contains percent phrase.
+     * @return
+     *         Length of phrase inside string, returns -1 when no phrase found.
+     */
+    private static int getPercentPhraseLengthIfContains(String valueToCheck) {
+        int result = -1;
+        for (String phrase : PERCENT_PHRASES) {
+            int indx = getPhraseLengthIfContains(valueToCheck, phrase);
+            if (indx != -1) {
+                result = indx;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Method to get length of given phrase in given string to check, method checks if phrase exist on
+     * the end of given string.
+     *
+     * @param valueToCheck
+     *            String which gonna be checked if contains phrase.
+     * @param phrase
+     *            Phrase to be looked for on the end of given string.
+     * @return
+     *         Length of phrase inside string, returns -1 when phrase wasn't found.
+     */
+    private static int getPhraseLengthIfContains(String valueToCheck, String phrase) {
+        int searchValueLength = phrase.length();
+
+        if (valueToCheck.length() > searchValueLength) {
+            String subValue = valueToCheck.substring(valueToCheck.length() - searchValueLength);
+            if (subValue.equals(phrase)) {
+                return searchValueLength;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Method to calculate percent of given max heap memory.
+     *
+     * @param value
+     *            String which contains percent + percent phrase which gonna be use during calculations.
+     * @param percentPhraseLength
+     *            Length of percent phrase inside given value.
+     * @return
+     *         Size of byte buffer based on percent of max heap memory.
+     */
+    private static long calculatePercentOfMemory(String value, int percentPhraseLength) {
+        String realValue = value.substring(0, value.length() - percentPhraseLength);
+        double percent = Double.parseDouble(realValue) / 100;
+        long result = (long) (percent * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax());
+        return result;
+    }
+
+    /**
+     * Method to check if given value has any chars to be parsed.
+     *
+     * @param value
+     *            Value to be checked.
+     * @return
+     *         Result if value can be parsed.
+     */
+    private static boolean checkIfValueExistsToBeParsed(String value) {
+        return value != null && value.length() != 0;
+    }
+
+    /**
+     * Method to get size based on given string value. String can contains just a number or number +
+     * multiplier sign (like T, G, M or K).
+     *
+     * @param value
+     *            Given string to be parsed.
+     * @return
+     *         Size based on given string.
+     * @throws ParserConfigurationException
+     *             Exception when given value can't be parsed.
+     */
+    private static long parseByteValue(String value) throws ParserConfigurationException {
+        long result = -1;
+        long multiplier = 1;
+        long mul = 1000;
+        String realValue;
+        char sign = value.charAt(value.length() - 1);
+
+        switch (sign) {
+
+            case 'T':
+            case 't':
+                multiplier *= mul;
+
+            case 'G':
+            case 'g':
+                multiplier *= mul;
+
+            case 'M':
+            case 'm':
+                multiplier *= mul;
+
+            case 'K':
+            case 'k':
+                multiplier *= mul;
+                realValue = value.substring(0, value.length() - 1);
+                result = Integer.parseInt(realValue) * multiplier;
+                break;
+
+            case '%':
+                return result;
+
+            default:
+                if (sign >= '0' && sign <= '9') {
+                    result = Long.parseLong(value);
+                } else {
+
+                    throw new ParserConfigurationException(
+                            Messages.getString("PropertyDefinition.1", new Object[] { "maxResultBuffer", MAX_RESULT_BUFFER_ACCETABLE_PATTERNS, value }));
+                }
+                break;
+        }
+        return result;
+    }
+
+    /**
+     * Method to adjust result memory limit size. If given memory is larger than 90% of max heap
+     * memory then it gonna be reduced to 90% of max heap memory.
+     *
+     * @param value
+     *            Size to be adjusted.
+     * @return
+     *         Adjusted size (original size or 90% of max heap memory)
+     */
+    private static long adjustResultSize(long value) {
+        if (value > 0.9 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()) {
+            long newResult = (long) (0.9 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax());
+
+            LOGGER.log(Level.WARNING, new StringBuilder("WARNING! Required to allocate ").append(value)
+                    .append(" bytes, which exceeded possible heap memory size. Assigned ").append(newResult).append(" bytes as limit.").toString());
+
+            value = newResult;
+        }
+        return value;
+    }
+
+}

--- a/src/testsuite/util/ConnectionPropertyMaxResultBufferParserTest.java
+++ b/src/testsuite/util/ConnectionPropertyMaxResultBufferParserTest.java
@@ -1,0 +1,87 @@
+/*
+  Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+
+  The MySQL Connector/J is licensed under the terms of the GPLv2
+  <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>, like most MySQL Connectors.
+  There are special exceptions to the terms and conditions of the GPLv2 as it is applied to
+  this software, see the FOSS License Exception
+  <http://www.mysql.com/about/legal/licensing/foss-exception.html>.
+
+  This program is free software; you can redistribute it and/or modify it under the terms
+  of the GNU General Public License as published by the Free Software Foundation; version 2
+  of the License.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with this
+  program; if not, write to the Free Software Foundation, Inc., 51 Franklin St, Fifth
+  Floor, Boston, MA 02110-1301  USA
+
+ */
+
+package testsuite.util;
+
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import src.com.mysql.jdbc.util.ConnectionPropertyMaxResultBufferParser;
+import src.testsuite.BaseTestCase;
+
+public class ConnectionPropertyMaxResultBufferParserTest extends BaseTestCase {
+
+    public ConnectionPropertyMaxResultBufferParserTest(String name) {
+        super(name);
+    }
+
+    /**
+     * Runs all test cases in this test suite
+     *
+     * @param args
+     */
+    public static void main(String[] args) {
+        junit.textui.TestRunner.run(ConnectionPropertyMaxResultBufferParserTest.class);
+    }
+
+    public void testGetMaxResultBufferValue() {
+        try {
+            Collection<Object[]> data = data();
+            for (Object[] item : data) {
+                long result = ConnectionPropertyMaxResultBufferParser.parseProperty((String) item[0]);
+                assertEquals("Expected :" + (Long) item[1] + " get: " + result, ((Long) item[1]).longValue(), result);
+            }
+        } catch (ParserConfigurationException e) {
+            //shouldn't occur
+            fail();
+        }
+    }
+
+    public void testGetParserConfigurationException() {
+        assertThrows(ParserConfigurationException.class, new Callable<Void>() {
+            public Void call() throws Exception {
+                ConnectionPropertyMaxResultBufferParser.parseProperty("abc");
+                return null;
+            }
+        });
+    }
+
+    private Collection<Object[]> data() {
+        Object[][] data = new Object[][] { { "100", 100L }, { "10K", 10L * 1000 }, { "25M", 25L * 1000 * 1000 },
+                //next two should be too big
+                { "35G", (long) (0.90 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()) },
+                { "1T", (long) (0.90 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()) },
+                //percent test
+                { "5p", (long) (0.05 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()) },
+                { "10pct", (long) (0.10 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()) },
+                { "15percent", (long) (0.15 * ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax()) },
+                //for testing empty property
+                { "", -1 }, { null, -1 } };
+        return Arrays.asList(data);
+    }
+
+}


### PR DESCRIPTION
Add new property maxResultBuffer. Limits the number of bytes of the read result set.
It can be declare as:

size of bytes (100, 100K, 100M, 100G, 100T);
percent of max heap memory (i.e. 10p, 10pct, 10percent).
Additionally there is validation if given value is not bigger than 90% of max memory heap.
If the new property is not declared, the driver works as before.

Commit made for Heimdalldata's request to solve memory problem during reading result set.