### PR TITLE
Fix for Bug #100294

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/ServerPreparedQueryBindValue.java
+++ b/src/main/core-impl/java/com/mysql/cj/ServerPreparedQueryBindValue.java
@@ -79,6 +79,8 @@ public class ServerPreparedQueryBindValue extends ClientPreparedQueryBindValue i
         this.bufferType = copyMe.bufferType;
         this.calendar = copyMe.calendar;
         this.charEncoding = copyMe.charEncoding;
+        this.cacheDefaultTimezone = copyMe.cacheDefaultTimezone;
+        this.defaultTimeZone = copyMe.defaultTimeZone;
     }
 
     @Override


### PR DESCRIPTION
The change ensures, that cacheDefaultTimezone and defaultTimeZone are copied in the copy constructor ServerPreparedQueryBindValue(ServerPreparedQueryBindValue copyMe). I have already signed the Oracle Contribution Agreement (OCA). 