### PR TITLE
#101242 - allow to pass InputStreams to prepared statement's setObject

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/AbstractQueryBindings.java
+++ b/src/main/core-impl/java/com/mysql/cj/AbstractQueryBindings.java
@@ -227,11 +227,18 @@ public abstract class AbstractQueryBindings<T extends BindValue> implements Quer
             setNull(parameterIndex);
             return;
         }
-        MysqlType defaultMysqlType = DEFAULT_MYSQL_TYPES.get(parameterObj.getClass());
+
+        MysqlType defaultMysqlType = null;
+
+        for (Map.Entry<Class<?>, MysqlType> entry : DEFAULT_MYSQL_TYPES.entrySet()) {
+            if (entry.getKey().isInstance(parameterObj)) {
+                defaultMysqlType = entry.getValue();
+                break;
+            }
+        }
 
         if (defaultMysqlType != null) {
             setObject(parameterIndex, parameterObj, defaultMysqlType);
-
         } else {
             setSerializableObject(parameterIndex, parameterObj); // TODO maybe default to error?
         }

--- a/src/main/core-impl/java/com/mysql/cj/AbstractQueryBindings.java
+++ b/src/main/core-impl/java/com/mysql/cj/AbstractQueryBindings.java
@@ -210,7 +210,6 @@ public abstract class AbstractQueryBindings<T extends BindValue> implements Quer
         DEFAULT_MYSQL_TYPES.put(Double.class, MysqlType.DOUBLE);
         DEFAULT_MYSQL_TYPES.put(byte[].class, MysqlType.BINARY);
         DEFAULT_MYSQL_TYPES.put(Boolean.class, MysqlType.BOOLEAN);
-        DEFAULT_MYSQL_TYPES.put(Boolean.class, MysqlType.BOOLEAN);
         DEFAULT_MYSQL_TYPES.put(LocalDate.class, MysqlType.DATE);
         DEFAULT_MYSQL_TYPES.put(LocalTime.class, MysqlType.TIME);
         DEFAULT_MYSQL_TYPES.put(LocalDateTime.class, MysqlType.DATETIME); // TODO default JDBC mapping is TIMESTAMP, see B-4
@@ -228,12 +227,18 @@ public abstract class AbstractQueryBindings<T extends BindValue> implements Quer
             return;
         }
 
+        Class<?> parameterClass = parameterObj.getClass();
+
         MysqlType defaultMysqlType = null;
 
-        for (Map.Entry<Class<?>, MysqlType> entry : DEFAULT_MYSQL_TYPES.entrySet()) {
-            if (entry.getKey().isInstance(parameterObj)) {
-                defaultMysqlType = entry.getValue();
-                break;
+        if (DEFAULT_MYSQL_TYPES.containsKey(parameterClass)) {
+            defaultMysqlType = DEFAULT_MYSQL_TYPES.get(parameterObj.getClass());
+        } else {
+            for (Map.Entry<Class<?>, MysqlType> entry : DEFAULT_MYSQL_TYPES.entrySet()) {
+                if (entry.getKey().isInstance(parameterObj)) {
+                    defaultMysqlType = entry.getValue();
+                    break;
+                }
             }
         }
 

--- a/src/test/java/testsuite/regression/StatementRegressionTest.java
+++ b/src/test/java/testsuite/regression/StatementRegressionTest.java
@@ -11238,4 +11238,31 @@ public class StatementRegressionTest extends BaseTestCase {
             }
         }
     }
+
+    /**
+     * #101242 - Ensure that InputStreams can be passed to PreparedStatement's setObject()
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testBug101242() throws Exception {
+        createTable("testBug101242", "(c BLOB)");
+
+        byte[] value = "TEST".getBytes();
+
+        this.conn = getNewConnection();
+        InputStream inputStream = new ByteArrayInputStream(value);
+
+        this.pstmt = this.conn.prepareStatement("INSERT INTO testBug101242(c) VALUES(?)");
+        this.pstmt.setObject(1, inputStream);
+        this.pstmt.execute();
+        this.pstmt.close();
+
+        this.pstmt = this.conn.prepareStatement("SELECT c FROM testBug101242 LIMIT 1");
+        ResultSet resultSet = this.pstmt.executeQuery();
+
+        resultSet.next();
+
+        assertByteArrayEquals("Different value retrieved than inserted", value, resultSet.getBytes("c"));
+    }
 }


### PR DESCRIPTION
Fixes the bug https://bugs.mysql.com/bug.php?id=101242 

The regression that was introduced in `8.0.22` does not allow to pass `InputStream` to `setObject` method in prepared statements. Before the regression was introduced, the correct MySQL type was determined using `isinstance`, but in `8.0.22` this was changed to a key look up of a map, which meant that when an instance of `ByteArrayInputStream` (or any other implementation of `InputStream`) was passed to `setObject`, it could not be found in the map, and the code would fail later when the driver tried to serialise the parameter.

This PR adds fallback logic to iterate over the map and check if the parameter is instance of any key in the map to lookup the correct value in the map if the mapping to MySQL mapping could not be found in the map.
