### PR TITLE
Fix ResultSet.getLong() throws NumberOutOfRange: Invalid integer format for value '4294967295'

### DIFF
--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlTextValueDecoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlTextValueDecoder.java
@@ -102,7 +102,7 @@ public class MysqlTextValueDecoder implements ValueDecoder {
     }
 
     public <T> T decodeInt4(byte[] bytes, int offset, int length, ValueFactory<T> vf) {
-        return vf.createFromLong(getInt(bytes, offset, offset + length));
+        return vf.createFromLong(getLong(bytes, offset, offset + length));
     }
 
     public <T> T decodeUInt8(byte[] bytes, int offset, int length, ValueFactory<T> vf) {


### PR DESCRIPTION
Fix `ResultSet.getLong()` throws `com.mysql.cj.exceptions.NumberOutOfRange: Invalid integer format for value '4294967295'.`

For example:
```
java.sql.SQLDataException: Invalid integer format for value '4294967295'
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:114)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:97)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:89)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:63)
	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:73)
	at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:92)
	at com.mysql.cj.jdbc.result.ResultSetImpl.getObject(ResultSetImpl.java:1393)
	at com.mysql.cj.jdbc.result.ResultSetImpl.getLong(ResultSetImpl.java:823)
	at <my_application>
Caused by: com.mysql.cj.exceptions.NumberOutOfRange: Invalid integer format for value '4294967295'
	at com.mysql.cj.protocol.a.MysqlTextValueDecoder.getInt(MysqlTextValueDecoder.java:154)
	at com.mysql.cj.protocol.a.MysqlTextValueDecoder.decodeInt4(MysqlTextValueDecoder.java:105)
	at com.mysql.cj.protocol.result.AbstractResultsetRow.decodeAndCreateReturnValue(AbstractResultsetRow.java:160)
	at com.mysql.cj.protocol.result.AbstractResultsetRow.getValueFromBytes(AbstractResultsetRow.java:241)
	at com.mysql.cj.protocol.a.result.TextBufferRow.getValue(TextBufferRow.java:132)
	at com.mysql.cj.jdbc.result.ResultSetImpl.getObject(ResultSetImpl.java:1301)
```
Not that it matters but this particular `ResultSet` is from a call to `DatabaseMetaData.getProcedureColumns()`.
