### PR TITLE
BigDecimal.toPlainString no need to check decimal exponent.

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/util/StringUtils.java
+++ b/src/main/core-api/java/com/mysql/cj/util/StringUtils.java
@@ -832,6 +832,22 @@ public class StringUtils {
      * @return the ASCII string
      */
     public static String toAsciiString(byte[] buffer, int startPos, int length) {
+        return new String(toAsciiCharArray(buffer, startPos, length));
+    }
+
+    /**
+     * Returns the bytes as an ASCII String.
+     *
+     * @param buffer
+     *            the bytes to convert
+     * @param startPos
+     *            the position to start converting
+     * @param length
+     *            the length of the string to convert
+     *
+     * @return the ASCII char array
+     */
+    public static char[] toAsciiCharArray(byte[] buffer, int startPos, int length) {
         char[] charArray = new char[length];
         int readpoint = startPos;
 
@@ -840,7 +856,7 @@ public class StringUtils {
             readpoint++;
         }
 
-        return new String(charArray);
+        return charArray;
     }
 
     /**

--- a/src/main/core-impl/java/com/mysql/cj/AbstractQueryBindings.java
+++ b/src/main/core-impl/java/com/mysql/cj/AbstractQueryBindings.java
@@ -962,7 +962,7 @@ public abstract class AbstractQueryBindings<T extends BindValue> implements Quer
                     case LONGTEXT:
                     case JSON:
                         if (parameterObj instanceof BigDecimal) {
-                            setString(parameterIndex, (StringUtils.fixDecimalExponent(((BigDecimal) parameterObj).toPlainString())));
+                            setString(parameterIndex, ((BigDecimal) parameterObj).toPlainString());
                         } else {
                             setString(parameterIndex, parameterObj.toString());
                         }
@@ -1000,7 +1000,7 @@ public abstract class AbstractQueryBindings<T extends BindValue> implements Quer
                     case LONGTEXT:
                     case JSON:
                         if (parameterObj instanceof BigDecimal) {
-                            setString(parameterIndex, (StringUtils.fixDecimalExponent(((BigDecimal) parameterObj).toPlainString())));
+                            setString(parameterIndex, ((BigDecimal) parameterObj).toPlainString());
                         } else if (parameterObj instanceof java.sql.Clob) {
                             setClob(parameterIndex, (java.sql.Clob) parameterObj);
                         } else {

--- a/src/main/core-impl/java/com/mysql/cj/ClientPreparedQueryBindings.java
+++ b/src/main/core-impl/java/com/mysql/cj/ClientPreparedQueryBindings.java
@@ -135,7 +135,7 @@ public class ClientPreparedQueryBindings extends AbstractQueryBindings<ClientPre
         if (x == null) {
             setNull(parameterIndex);
         } else {
-            setValue(parameterIndex, StringUtils.fixDecimalExponent(x.toPlainString()), MysqlType.DECIMAL);
+            setValue(parameterIndex, x.toPlainString(), MysqlType.DECIMAL);
         }
     }
 

--- a/src/main/core-impl/java/com/mysql/cj/ServerPreparedQueryBindings.java
+++ b/src/main/core-impl/java/com/mysql/cj/ServerPreparedQueryBindings.java
@@ -166,7 +166,7 @@ public class ServerPreparedQueryBindings extends AbstractQueryBindings<ServerPre
         } else {
             ServerPreparedQueryBindValue binding = getBinding(parameterIndex, false);
             this.sendTypesToServer.compareAndSet(false, binding.resetToType(MysqlType.FIELD_TYPE_NEWDECIMAL, this.numberOfExecutions));
-            binding.value = StringUtils.fixDecimalExponent(x.toPlainString());
+            binding.value = x.toPlainString();
             binding.parameterType = MysqlType.DECIMAL;
         }
     }

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlBinaryValueDecoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlBinaryValueDecoder.java
@@ -261,7 +261,7 @@ public class MysqlBinaryValueDecoder implements ValueDecoder {
     }
 
     public <T> T decodeDecimal(byte[] bytes, int offset, int length, ValueFactory<T> vf) {
-        BigDecimal d = new BigDecimal(StringUtils.toAsciiString(bytes, offset, length));
+        BigDecimal d = new BigDecimal(StringUtils.toAsciiCharArray(bytes, offset, length));
         return vf.createFromBigDecimal(d);
     }
 

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlTextValueDecoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/MysqlTextValueDecoder.java
@@ -135,7 +135,7 @@ public class MysqlTextValueDecoder implements ValueDecoder {
     }
 
     public <T> T decodeDecimal(byte[] bytes, int offset, int length, ValueFactory<T> vf) {
-        BigDecimal d = new BigDecimal(StringUtils.toAsciiString(bytes, offset, length));
+        BigDecimal d = new BigDecimal(StringUtils.toAsciiCharArray(bytes, offset, length));
         return vf.createFromBigDecimal(d);
     }
 


### PR DESCRIPTION
so we could replace StringUtils.fixDecimalExponent(BigDecimal.toPlainString) directly to BigDecimal.toPlainString

Replace BigDecimal(String) to BigDecimal(char[]) to reduce memory allocation

Signed-off-by: Baoyi Chen <chen.bao.yi@qq.com>