### PR TITLE
add support for java.time.Instant in rs.getObject call

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/result/InstantValueFactory.java
+++ b/src/main/core-impl/java/com/mysql/cj/result/InstantValueFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj.result;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+import com.mysql.cj.conf.PropertyKey;
+import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.protocol.InternalDate;
+import com.mysql.cj.protocol.InternalTime;
+import com.mysql.cj.protocol.InternalTimestamp;
+
+/**
+ * A value factory for creating {@link java.time.Instant} values. It usually can be mapped from a
+ * {@link java.sql.Timestamp} or a {@link Long}, and are created from fields returned from the db without a timezone.
+ * In order to create a <i>point-in-time</i>, a {@link ZoneId} (preferred) or {@link TimeZone} must be provided to
+ * interpret the fields.
+ */
+public class InstantValueFactory extends AbstractDateTimeValueFactory<Instant> {
+
+    private final ZoneId defaultZoneId;
+
+    private final ZoneId connectionZoneId;
+
+    public InstantValueFactory(PropertySet pset, ZoneId defaultZoneId, ZoneId connectionZoneId) {
+        super(pset);
+        this.defaultZoneId = defaultZoneId;
+        this.connectionZoneId = connectionZoneId;
+    }
+
+    public InstantValueFactory(PropertySet pset, TimeZone defaultTimeZone, TimeZone connectionTimeZone) {
+        this(pset, defaultTimeZone.toZoneId(), connectionTimeZone.toZoneId());
+    }
+
+    private boolean preserveInstant() {
+        return pset.getBooleanProperty(PropertyKey.preserveInstants).getValue();
+    }
+
+    private ZoneId getZoneId() {
+        return preserveInstant() ? connectionZoneId : defaultZoneId;
+    }
+
+    @Override
+    public String getTargetTypeName() {
+        return Instant.class.getName();
+    }
+
+    @Override
+    Instant localCreateFromDate(InternalDate it) {
+        return LocalDate.of(it.getYear(), it.getMonth(), it.getDay())
+            .atStartOfDay()
+            .atZone(getZoneId())
+            .toInstant();
+    }
+
+    @Override
+    Instant localCreateFromTime(InternalTime it) {
+        LocalTime localTime = LocalTime.of(it.getHours(), it.getMinutes(), it.getSeconds(), it.getNanos());
+        return LocalDate.ofEpochDay(0).atTime(localTime)
+            .atZone(getZoneId())
+            .toInstant();
+    }
+
+    @Override
+    Instant localCreateFromTimestamp(InternalTimestamp its) {
+        return LocalDateTime.of(
+                its.getYear(),
+                its.getMonth(),
+                its.getDay(),
+                its.getHours(),
+                its.getMinutes(),
+                its.getSeconds(),
+                its.getNanos()
+            ).atZone(getZoneId())
+            .toInstant();
+    }
+
+    @Override
+    Instant localCreateFromDatetime(InternalTimestamp its) {
+        return LocalDateTime.of(
+                its.getYear(),
+                its.getMonth(),
+                its.getDay(),
+                its.getHours(),
+                its.getMinutes(),
+                its.getSeconds(),
+                its.getNanos()
+            ).atZone(getZoneId())
+            .toInstant();
+    }
+
+    @Override
+    public Instant createFromLong(long l) {
+        return Instant.ofEpochMilli(l);
+    }
+}

--- a/src/test/java/com/mysql/cj/result/InstantValueFactoryTest.java
+++ b/src/test/java/com/mysql/cj/result/InstantValueFactoryTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj.result;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.Callable;
+
+import com.mysql.cj.conf.DefaultPropertySet;
+import com.mysql.cj.conf.PropertySet;
+import com.mysql.cj.exceptions.DataConversionException;
+import com.mysql.cj.protocol.InternalDate;
+import com.mysql.cj.protocol.InternalTime;
+import com.mysql.cj.protocol.InternalTimestamp;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class InstantValueFactoryTest extends CommonAsserts {
+    PropertySet pset = new DefaultPropertySet();
+    ValueFactory<Instant> vf = new InstantValueFactory(this.pset, ZoneId.of("UTC"), ZoneId.of("UTC"));
+
+    @Test
+    void testBasics() {
+        assertEquals("java.time.Instant", vf.getTargetTypeName());
+    }
+
+    @Test
+    void testCreateFromDate() {
+        assertEquals(Instant.parse("2022-03-22T00:00:00Z"), vf.createFromDate(new InternalDate(2022, 3, 22)));
+    }
+
+    @Test
+    void testCreateFromTime() {
+        assertEquals(Instant.parse("1970-01-01T15:31:23Z"), vf.createFromTime(new InternalTime(15, 31, 23, 0, 0)));
+    }
+
+    @Test
+    void testCreateFromTimestamp() {
+        assertEquals(Instant.parse("2022-03-22T15:31:23Z"), vf.createFromTimestamp(new InternalTimestamp(2022, 3, 22, 15, 31, 23, 0, 0)));
+    }
+
+    @Test
+    void testCreateFromLong() {
+        Instant instant = Instant.parse("2022-03-22T15:31:23.123Z");
+        assertEquals(instant, vf.createFromLong(instant.toEpochMilli()));
+    }
+
+    @Test
+    public void testCreateFromDouble() {
+        assertThrows(DataConversionException.class, "Unsupported conversion from DOUBLE to java.time.Instant", (Callable<Void>) () -> {
+            vf.createFromDouble(2018.0);
+            return null;
+        });
+    }
+
+    @Test
+    public void testCreateFromNull() {
+        assertNull(this.vf.createFromNull());
+    }
+}

--- a/src/test/java/testsuite/simple/ResultSetTest.java
+++ b/src/test/java/testsuite/simple/ResultSetTest.java
@@ -50,6 +50,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -642,7 +643,9 @@ public class ResultSetTest extends BaseTestCase {
             assertEquals(testSqlDate, this.rs.getDate(2), row);
             assertEquals(testSqlTime, this.rs.getTime(3), row);
             assertEquals(testTSFromDatetime, this.rs.getTimestamp(4), row);
+            assertEquals(testTSFromDatetime.toInstant(), this.rs.getObject(4, Instant.class), row);
             assertEquals(testTSFromTimestamp, this.rs.getTimestamp(5), row);
+            assertEquals(testTSFromTimestamp.toInstant(), this.rs.getObject(5, Instant.class), row);
 
             assertEquals(testLocalDate, this.rs.getObject(2, LocalDate.class), row);
             assertEquals(testLocalTime, this.rs.getObject(3, LocalTime.class), row);
@@ -654,7 +657,9 @@ public class ResultSetTest extends BaseTestCase {
             assertEquals(testSqlDate, this.rs.getDate("d"), row);
             assertEquals(testSqlTime, this.rs.getTime("t"), row);
             assertEquals(testTSFromDatetime, this.rs.getTimestamp("dt"), row);
+            assertEquals(testTSFromDatetime.toInstant(), this.rs.getObject("dt", Instant.class), row);
             assertEquals(testTSFromTimestamp, this.rs.getTimestamp("ts"), row);
+            assertEquals(testTSFromTimestamp.toInstant(), this.rs.getObject("ts", Instant.class), row);
 
             assertEquals(testLocalDate, this.rs.getObject("d", LocalDate.class), row);
             assertEquals(testLocalTime, this.rs.getObject("t", LocalTime.class), row);


### PR DESCRIPTION
Currently a list of `java.time.*` types are supported (outside of normal call of `ResultSet`):
- `LocalDate`
- `LocalTime`
- `LocalDateTime`
- `ZonedDateTime`
- `OffsetDateTime`
via the `getObject(columnIndex, classOfT)` generic call.

I find that `Instant` support is missing can I will get err when I try to map a `timestamp` value to an `Instant` in java.

In this pull request the support for `getInstant` and `getObject` with `Instant` is added. 

### Testing

Tested locally using:

```bash
ant -Dcom.mysql.cj.testsuite.test.class=com.mysql.cj.result.InstantValueFactoryTest test
ant -Dcom.mysql.cj.testsuite.test.class=testsuite.simple.ResultSetTest test
```
