### PR TITLE
Add a first implementation of the Data Service Specification for JDBC

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -756,7 +756,7 @@ See also com.mysql.cj.conf.PropertyDefinitions.SYSP_* variables for other test o
         <property name="com.mysql.cj.build.meta-inf.integration-imports" value="com.mchange.v2.c3p0;version=&quot;[0.9.1.2,1.0.0)&quot;;resolution:=optional" />
         <property name="com.mysql.cj.build.meta-inf.logging-imports" value="org.slf4j;resolution:=optional" />
         <property name="com.mysql.cj.build.meta-inf.xdevapi-imports" value="com.google.protobuf;resolution:=optional" />
-
+    	<property name="com.mysql.cj.build.meta-inf.osgijdbc-imports" value="org.osgi.service.jdbc,org.osgi.framework" />
 
         <property name="com.mysql.cj.build.meta-inf.driver-exports"
                   value="com.mysql.cj.jdbc;version=&quot;${com.mysql.cj.build.meta-inf.osgid-version}&quot;;uses:=&quot;javax.management,javax.naming,javax.naming.spi,javax.net.ssl,javax.sql,javax.transaction.xa,javax.xml.parsers,javax.xml.stream,javax.xml.transform,javax.xml.transform.dom,javax.xml.transform.sax,javax.xml.transform.stax,javax.xml.transform.stream,org.xml.sax&quot;" />
@@ -805,10 +805,11 @@ See also com.mysql.cj.conf.PropertyDefinitions.SYSP_* variables for other test o
             <attribute name="Bundle-Name" value="Oracle Corporation's JDBC and XDevAPI Driver for MySQL" />
             <attribute name="Bundle-ManifestVersion" value="2" />
             <attribute name="Bundle-SymbolicName" value="com.mysql.cj" />
+        	<attribute name="Bundle-Activator" value="com.mysql.cj.osgi.ConnectorJActivator" />
             <attribute name="Export-Package"
                        value="${com.mysql.cj.build.meta-inf.driver-exports},${com.mysql.cj.build.meta-inf.core-exports},${com.mysql.cj.build.meta-inf.protocol-exports},${com.mysql.cj.build.meta-inf.generated-exports},${com.mysql.cj.build.meta-inf.logging-exports},${com.mysql.cj.build.meta-inf.util-exports},${com.mysql.cj.build.meta-inf.exceptions-exports},${com.mysql.cj.build.meta-inf.ha-exports},${com.mysql.cj.build.meta-inf.interceptors-exports},${com.mysql.cj.build.meta-inf.integration-exports},${com.mysql.cj.build.meta-inf.configs-exports},${com.mysql.cj.build.meta-inf.legacy-exports},${com.mysql.cj.build.meta-inf.jdbc-exports},${com.mysql.cj.build.meta-inf.xdevapi-exports},${com.mysql.cj.build.meta-inf.admin-exports}" />
             <attribute name="Import-Package"
-                       value="${com.mysql.cj.build.meta-inf.crypto-imports},${com.mysql.cj.build.meta-inf.security-imports},${com.mysql.cj.build.meta-inf.jdbc4-imports},${com.mysql.cj.build.meta-inf.jee-imports},${com.mysql.cj.build.meta-inf.jmx-imports},${com.mysql.cj.build.meta-inf.integration-imports},${com.mysql.cj.build.meta-inf.logging-imports},${com.mysql.cj.build.meta-inf.xdevapi-imports}" />
+                       value="${com.mysql.cj.build.meta-inf.crypto-imports},${com.mysql.cj.build.meta-inf.security-imports},${com.mysql.cj.build.meta-inf.jdbc4-imports},${com.mysql.cj.build.meta-inf.jee-imports},${com.mysql.cj.build.meta-inf.jmx-imports},${com.mysql.cj.build.meta-inf.integration-imports},${com.mysql.cj.build.meta-inf.logging-imports},${com.mysql.cj.build.meta-inf.xdevapi-imports},${com.mysql.cj.build.meta-inf.osgijdbc-imports}" />
         </manifest>
 
         <!-- Add legal notices and INFO files to META-INF -->

--- a/src/main/core-impl/java/com/mysql/cj/osgi/ConnectorJActivator.java
+++ b/src/main/core-impl/java/com/mysql/cj/osgi/ConnectorJActivator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj.osgi;
+
+import java.util.Hashtable;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.jdbc.DataSourceFactory;
+
+public class ConnectorJActivator implements BundleActivator {
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        Hashtable<String, Object> properties = new Hashtable<>();
+        properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_CLASS, com.mysql.cj.jdbc.Driver.class.getName());
+        properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_NAME, com.mysql.cj.Constants.CJ_NAME);
+        properties.put(DataSourceFactory.OSGI_JDBC_DRIVER_VERSION, com.mysql.cj.Constants.CJ_MAJOR_VERSION + "." + com.mysql.cj.Constants.CJ_MINOR_VERSION);
+        context.registerService(DataSourceFactory.class, new ConnectorJDataSourceFactory(), properties);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        //everything will be unregistered automatically
+    }
+
+}

--- a/src/main/core-impl/java/com/mysql/cj/osgi/ConnectorJDataSourceFactory.java
+++ b/src/main/core-impl/java/com/mysql/cj/osgi/ConnectorJDataSourceFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is also distributed with certain software (including but not
+ * limited to OpenSSL) that is licensed under separate terms, as designated in a
+ * particular file or component or in included license documentation. The
+ * authors of MySQL hereby grant you an additional permission to link the
+ * program and your derivative works with the separately licensed software that
+ * they have included with MySQL.
+ *
+ * Without limiting anything contained in the foregoing, this file, which is
+ * part of MySQL Connector/J, is also subject to the Universal FOSS Exception,
+ * version 1.0, a copy of which can be found at
+ * http://oss.oracle.com/licenses/universal-foss-exception.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License, version 2.0,
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+ */
+
+package com.mysql.cj.osgi;
+
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+
+import javax.sql.ConnectionPoolDataSource;
+import javax.sql.DataSource;
+import javax.sql.XADataSource;
+
+import org.osgi.service.jdbc.DataSourceFactory;
+
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
+import com.mysql.cj.jdbc.MysqlDataSource;
+import com.mysql.cj.jdbc.MysqlXADataSource;
+import com.mysql.cj.jdbc.NonRegisteringDriver;
+
+public class ConnectorJDataSourceFactory implements DataSourceFactory {
+
+    @Override
+    public DataSource createDataSource(Properties props) throws SQLException {
+        MysqlDataSource dataSource = new MysqlDataSource();
+        setBasicProperties(dataSource, props);
+        return dataSource;
+    }
+
+    private void setBasicProperties(MysqlDataSource dataSource, Properties props) throws SQLException {
+        if (props == null || props.isEmpty()) {
+            return;
+        }
+        setProperty(JDBC_DATABASE_NAME, dataSource::setDatabaseName, props);
+        //Supported? setProperty(JDBC_DATASOURCE_NAME, dataSource::, props);
+        setProperty(JDBC_DESCRIPTION, dataSource::setDescription, props);
+        //Supported? setProperty(JDBC_NETWORK_PROTOCOL, dataSource::, props);
+        setProperty(JDBC_PASSWORD, dataSource::setPassword, props);
+        setProperty(JDBC_PORT_NUMBER, dataSource::setPortNumber, props);
+        //Supported? setProperty(JDBC_ROLE_NAME, dataSource::, props);
+        setProperty(JDBC_SERVER_NAME, dataSource::setServerName, props);
+        setProperty(JDBC_USER, dataSource::setUser, props);
+        setProperty(JDBC_URL, dataSource::setURL, props);
+    }
+
+    private static void setProperty(String key, Consumer<String> setter, Properties props) {
+        String value = props.getProperty(key);
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+
+    private static void setProperty(String key, IntConsumer setter, Properties props) throws SQLException {
+        String value = props.getProperty(key);
+        if (value != null) {
+            try {
+                setter.accept(Integer.parseInt(value));
+            } catch (NumberFormatException e) {
+                throw new SQLException("can't parse " + key + " as an int", e);
+            }
+        }
+    }
+
+    @Override
+    public ConnectionPoolDataSource createConnectionPoolDataSource(Properties props) throws SQLException {
+        MysqlConnectionPoolDataSource poolDataSource = new MysqlConnectionPoolDataSource();
+        setBasicProperties(poolDataSource, props);
+        return poolDataSource;
+    }
+
+    @Override
+    public XADataSource createXADataSource(Properties props) throws SQLException {
+        MysqlXADataSource xaDataSource = new MysqlXADataSource();
+        setBasicProperties(xaDataSource, props);
+        return xaDataSource;
+    }
+
+    @Override
+    public Driver createDriver(Properties props) throws SQLException {
+        //we use the non registering one here, as no need to register it
+        return new NonRegisteringDriver();
+    }
+
+}


### PR DESCRIPTION
Described at: https://bugs.mysql.com/bug.php?id=107586

This requires the following new libraries to be added to the build:

- https://repo1.maven.org/maven2/org/osgi/osgi.core/8.0.0/osgi.core-8.0.0.jar
- https://repo1.maven.org/maven2/org/osgi/org.osgi.service.jdbc/1.0.1/org.osgi.service.jdbc-1.0.1.jar

Also i noticed that one already needs to add
- https://repo1.maven.org/maven2/com/mchange/c3p0/0.9.5.5/c3p0-0.9.5.5.jar

what is not mentioned on this page: https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-installing-source.html