### PR TITLE
Fix clear_password_plugin failed bug

### DIFF
--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeAuthenticationProvider.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeAuthenticationProvider.java
@@ -644,7 +644,7 @@ public class NativeAuthenticationProvider implements AuthenticationProvider<Nati
         } else {
             // send 1 byte length of auth-response and string[n] auth-response
             last_sent.writeInteger(IntegerDataType.INT1, authData.getPayloadLength());
-            last_sent.writeBytes(StringSelfDataType.STRING_EOF, authData.getByteBuffer());
+            last_sent.writeBytes(StringSelfDataType.STRING_EOF, authData.getByteBuffer(), 0, authData.getPayloadLength());
         }
 
         if (this.useConnectWithDb) {


### PR DESCRIPTION
The authData may contain some padding zeros, because of buffer expanding. So we should only write the data in range [0, payloadLength).