### PR TITLE
 Upgrade Protocol Buffers dependency to protobuf-java-3.21.9 to avoid CVE warnings.

### DIFF
--- a/src/build/misc/pom.xml
+++ b/src/build/misc/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.19.4</version>
+      <version>3.21.9</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
update protobuf-java to 3.21.9 to avoid CVE warnings.