### PR TITLE
Replace connectionMutex and synchronized blocks with a ReentrantLock.…

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/MysqlConnection.java
+++ b/src/main/core-api/java/com/mysql/cj/MysqlConnection.java
@@ -30,6 +30,7 @@
 package com.mysql.cj;
 
 import java.util.Properties;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.mysql.cj.conf.PropertySet;
 import com.mysql.cj.exceptions.ExceptionInterceptor;
@@ -56,7 +57,7 @@ public interface MysqlConnection {
      */
     Properties getProperties();
 
-    Object getConnectionMutex();
+    ReentrantLock getConnectionMutex();
 
     Session getSession();
 

--- a/src/main/core-api/java/com/mysql/cj/protocol/ResultsetRowsOwner.java
+++ b/src/main/core-api/java/com/mysql/cj/protocol/ResultsetRowsOwner.java
@@ -33,6 +33,8 @@ import com.mysql.cj.MysqlConnection;
 import com.mysql.cj.Query;
 import com.mysql.cj.Session;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 public interface ResultsetRowsOwner {
 
     void closeOwner(boolean calledExplicitly);
@@ -41,7 +43,7 @@ public interface ResultsetRowsOwner {
 
     Session getSession();
 
-    Object getSyncMutex();
+    ReentrantLock getSyncMutex();
 
     /**
      * StackTrace generated where ResultSet was created... used when profiling

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/result/ResultsetRowsCursor.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/result/ResultsetRowsCursor.java
@@ -31,6 +31,7 @@ package com.mysql.cj.protocol.a.result;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.mysql.cj.Messages;
 import com.mysql.cj.exceptions.ExceptionFactory;
@@ -204,7 +205,9 @@ public class ResultsetRowsCursor extends AbstractResultsetRows implements Result
             return;
         }
 
-        synchronized (this.owner.getSyncMutex()) {
+        ReentrantLock lock = this.owner.getSyncMutex();
+        lock.lock();
+        try {
             try {
                 boolean oldFirstFetchCompleted = this.firstFetchCompleted;
 
@@ -253,6 +256,8 @@ public class ResultsetRowsCursor extends AbstractResultsetRows implements Result
             } catch (Exception ex) {
                 throw ExceptionFactory.createException(ex.getMessage(), ex);
             }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ClientPreparedStatement.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ClientPreparedStatement.java
@@ -50,6 +50,7 @@ import java.sql.Timestamp;
 import java.sql.Wrapper;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.mysql.cj.BindValue;
 import com.mysql.cj.CancelQueryTask;
@@ -244,37 +245,53 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
     @Override
     public void addBatch() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             QueryBindings queryBindings = ((PreparedQuery) this.query).getQueryBindings();
             queryBindings.checkAllParametersSet();
             this.query.addBatch(queryBindings.clone());
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void addBatch(String sql) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             this.batchHasPlainStatements = true;
 
             super.addBatch(sql);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void clearBatch() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             this.batchHasPlainStatements = false;
 
             super.clearBatch();
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void clearParameters() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             for (BindValue bv : ((PreparedQuery) this.query).getQueryBindings().getBindValues()) {
                 bv.reset();
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -286,15 +303,21 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      *             if a database access error occurs or this method is called on a closed PreparedStatement
      */
     protected boolean checkReadOnlySafeStatement() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             return QueryInfo.isReadOnlySafeQuery(((PreparedQuery) this.query).getOriginalSql(), this.session.getServerSession().isNoBackslashEscapesSet())
                     || !this.connection.isReadOnly();
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean execute() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
 
             JdbcConnection locallyScopedConn = this.connection;
 
@@ -376,12 +399,16 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             }
 
             return ((rs != null) && rs.hasRows());
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     protected long[] executeBatchInternal() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
 
             if (this.connection.isReadOnly()) {
                 throw new SQLException(Messages.getString("PreparedStatement.25") + Messages.getString("PreparedStatement.26"),
@@ -421,6 +448,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
                 clearBatch();
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -435,7 +464,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      *             if a database access error occurs or this method is called on a closed PreparedStatement
      */
     protected long[] executePreparedBatchAsMultiStatement(int batchTimeout) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             // This is kind of an abuse, but it gets the job done
             if (this.batchedValuesClause == null) {
                 this.batchedValuesClause = ((PreparedQuery) this.query).getOriginalSql() + ";";
@@ -581,6 +612,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
                 clearBatch();
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -595,7 +628,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
     }
 
     private String generateMultiStatementForBatch(int numBatches) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             String origSql = ((PreparedQuery) this.query).getOriginalSql();
             StringBuilder newStatementSql = new StringBuilder((origSql.length() + 1) * numBatches);
 
@@ -607,6 +642,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             }
 
             return newStatementSql.toString();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -621,7 +658,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      *             if a database access error occurs or this method is called on a closed PreparedStatement
      */
     protected long[] executeBatchWithMultiValuesClause(int batchTimeout) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             JdbcConnection locallyScopedConn = this.connection;
 
             int numBatchedArgs = this.query.getBatchedArgs().size();
@@ -736,6 +775,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
                 stopQueryTimer(timeoutTask, false, false);
                 resetCancelledState();
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -750,7 +791,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      */
     protected long[] executeBatchSerially(int batchTimeout) throws SQLException {
 
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (this.connection == null) {
                 checkClosed();
             }
@@ -840,6 +883,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             }
 
             return (updateCounts != null) ? updateCounts : new long[0];
+        } finally {
+            lock.unlock();
         }
 
     }
@@ -870,8 +915,10 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      *             if an error occurs.
      */
     protected <M extends Message> ResultSetInternalMethods executeInternal(int maxRowsToRetrieve, M sendPacket, boolean createStreamingResultSet,
-            boolean queryIsSelectOnly, ColumnDefinition metadata, boolean isBatch) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+                                                                           boolean queryIsSelectOnly, ColumnDefinition metadata, boolean isBatch) throws SQLException {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             try {
 
                 JdbcConnection locallyScopedConnection = this.connection;
@@ -913,12 +960,16 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
                 throw npe;
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public java.sql.ResultSet executeQuery() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
 
             JdbcConnection locallyScopedConn = this.connection;
 
@@ -986,6 +1037,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             this.lastInsertId = this.results.getUpdateID();
 
             return this.results;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1000,13 +1053,17 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      * keys we need to gather for the batch.
      */
     protected long executeUpdateInternal(boolean clearBatchedGeneratedKeysAndWarnings, boolean isBatch) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (clearBatchedGeneratedKeysAndWarnings) {
                 clearWarnings();
                 this.batchedGeneratedKeys = null;
             }
 
             return executeUpdateInternal(((PreparedQuery) this.query).getQueryBindings(), isBatch);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1025,7 +1082,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      */
     protected long executeUpdateInternal(QueryBindings bindings, boolean isReallyBatch) throws SQLException {
 
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
 
             JdbcConnection locallyScopedConn = this.connection;
 
@@ -1081,6 +1140,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             this.lastInsertId = rs.getUpdateID();
 
             return this.updateCount;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1100,7 +1161,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      *             if a database access error occurs or this method is called on a closed PreparedStatement
      */
     protected ClientPreparedStatement prepareBatchedInsertSQL(JdbcConnection localConn, int numBatches) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ClientPreparedStatement pstmt = new ClientPreparedStatement(localConn, "Rewritten batch of: " + ((PreparedQuery) this.query).getOriginalSql(),
                     this.getCurrentDatabase(), getQueryInfo().getQueryInfoForBatch(numBatches));
             pstmt.setRetrieveGeneratedKeys(this.retrieveGeneratedKeys);
@@ -1109,26 +1172,38 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             getQueryAttributesBindings().runThroughAll(a -> ((JdbcStatement) pstmt).setAttribute(a.getName(), a.getValue()));
 
             return pstmt;
+        } finally {
+            lock.unlock();
         }
     }
 
     protected void setRetrieveGeneratedKeys(boolean flag) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             this.retrieveGeneratedKeys = flag;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public byte[] getBytesRepresentation(int parameterIndex) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             return ((PreparedQuery) this.query).getQueryBindings().getBytesRepresentation(getCoreParameterIndex(parameterIndex));
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public java.sql.ResultSetMetaData getMetaData() throws SQLException {
 
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             //
             // We could just tack on a LIMIT 0 here no matter what the  statement, and check if a result set was returned or not, but I'm not comfortable with
             // that, myself, so we take the "safer" road, and only allow metadata for _actual_ SELECTS (but not SHOWs).
@@ -1197,6 +1272,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             }
 
             return this.pstmtResultMetaData;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1224,7 +1301,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
     @Override
     public ParameterMetaData getParameterMetaData() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (this.parameterMetaData == null) {
                 if (this.session.getPropertySet().getBooleanProperty(PropertyKey.generateSimpleParameterMetadata).getValue()) {
                     this.parameterMetaData = new MysqlParameterMetadata(((PreparedQuery) this.query).getParameterCount());
@@ -1235,6 +1314,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             }
 
             return this.parameterMetaData;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1244,19 +1325,27 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
     }
 
     private void initializeFromQueryInfo() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
 
             int parameterCount = getQueryInfo().getStaticSqlParts().length - 1;
             ((PreparedQuery) this.query).setParameterCount(parameterCount);
             ((PreparedQuery) this.query).setQueryBindings(new NativeQueryBindings(parameterCount, this.session, NativeQueryBindValue::new));
             clearParameters();
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean isNull(int paramIndex) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             return ((PreparedQuery) this.query).getQueryBindings().getBindValues()[getCoreParameterIndex(paramIndex)].isNull();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1268,7 +1357,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
             return; // already closed
         }
 
-        synchronized (locallyScopedConn.getConnectionMutex()) {
+        ReentrantLock lock = locallyScopedConn.getConnectionMutex();
+        lock.lock();
+        try {
 
             // additional check in case Statement was closed
             // while current thread was waiting for lock
@@ -1288,17 +1379,23 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
             ((PreparedQuery) this.query).setOriginalSql(null);
             ((PreparedQuery) this.query).setQueryBindings(null);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public String getPreparedSql() {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (this.rewrittenBatchSize == 0) {
                 return ((PreparedQuery) this.query).getOriginalSql();
             }
 
             return getQueryInfo().getSqlForBatch();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1321,8 +1418,12 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
     }
 
     public ParameterBindings getParameterBindings() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             return new ParameterBindingsImpl((PreparedQuery) this.query, this.session, this.resultSetFactory);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1337,7 +1438,9 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
     }
 
     protected void checkBounds(int paramIndex, int parameterIndexOffset) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if ((paramIndex < 1)) {
                 throw SQLError.createSQLException(Messages.getString("PreparedStatement.49") + paramIndex + Messages.getString("PreparedStatement.50"),
                         MysqlErrorNumbers.SQL_STATE_ILLEGAL_ARGUMENT, this.exceptionInterceptor);
@@ -1350,6 +1453,8 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
                 throw SQLError.createSQLException(Messages.getString("PreparedStatement.63"), MysqlErrorNumbers.SQL_STATE_ILLEGAL_ARGUMENT,
                         this.exceptionInterceptor);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1366,162 +1471,254 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setAsciiStream(getCoreParameterIndex(parameterIndex), x, -1);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setAsciiStream(getCoreParameterIndex(parameterIndex), x, length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setAsciiStream(getCoreParameterIndex(parameterIndex), x, (int) length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBigDecimal(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBinaryStream(getCoreParameterIndex(parameterIndex), x, -1);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBinaryStream(getCoreParameterIndex(parameterIndex), x, length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBinaryStream(getCoreParameterIndex(parameterIndex), x, (int) length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBlob(int i, java.sql.Blob x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBlob(getCoreParameterIndex(i), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBinaryStream(getCoreParameterIndex(parameterIndex), inputStream, -1);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBinaryStream(getCoreParameterIndex(parameterIndex), inputStream, (int) length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBoolean(int parameterIndex, boolean x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBoolean(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setByte(int parameterIndex, byte x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setByte(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBytes(int parameterIndex, byte[] x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBytes(getCoreParameterIndex(parameterIndex), x, true);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBytes(int parameterIndex, byte[] x, boolean escapeIfNeeded) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBytes(getCoreParameterIndex(parameterIndex), x, escapeIfNeeded);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setCharacterStream(getCoreParameterIndex(parameterIndex), reader, -1);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setCharacterStream(getCoreParameterIndex(parameterIndex), reader, length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setCharacterStream(getCoreParameterIndex(parameterIndex), reader, (int) length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setCharacterStream(getCoreParameterIndex(parameterIndex), reader, -1);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setCharacterStream(getCoreParameterIndex(parameterIndex), reader, (int) length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setClob(int i, Clob x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setClob(getCoreParameterIndex(i), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setDate(int parameterIndex, Date x) throws java.sql.SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setDate(getCoreParameterIndex(parameterIndex), x, null);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setDate(getCoreParameterIndex(parameterIndex), x, cal);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setDouble(int parameterIndex, double x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setDouble(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1532,57 +1729,89 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
     @Override
     public void setInt(int parameterIndex, int x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setInt(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setLong(int parameterIndex, long x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setLong(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setBigInteger(int parameterIndex, BigInteger x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setBigInteger(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setNCharacterStream(getCoreParameterIndex(parameterIndex), value, -1);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setNCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setNCharacterStream(getCoreParameterIndex(parameterIndex), reader, length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setNCharacterStream(getCoreParameterIndex(parameterIndex), reader, -1);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setNCharacterStream(getCoreParameterIndex(parameterIndex), reader, length);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setNClob(int parameterIndex, NClob value) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setNClob(getCoreParameterIndex(parameterIndex), value);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1602,22 +1831,34 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
      */
     @Override
     public void setNString(int parameterIndex, String x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setNString(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setNull(getCoreParameterIndex(parameterIndex)); // MySQL ignores sqlType
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setNull(getCoreParameterIndex(parameterIndex));
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1628,14 +1869,20 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
     @Override
     public void setObject(int parameterIndex, Object parameterObj) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setObject(getCoreParameterIndex(parameterIndex), parameterObj);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setObject(int parameterIndex, Object parameterObj, int targetSqlType) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             try {
                 ((PreparedQuery) this.query).getQueryBindings().setObject(getCoreParameterIndex(parameterIndex), parameterObj,
                         MysqlType.getByJdbcType(targetSqlType), -1);
@@ -1643,23 +1890,31 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
                 throw SQLError.createSQLFeatureNotSupportedException(Messages.getString("Statement.UnsupportedSQLType") + JDBCType.valueOf(targetSqlType),
                         MysqlErrorNumbers.SQL_STATE_DRIVER_NOT_CAPABLE, this.exceptionInterceptor);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setObject(int parameterIndex, Object parameterObj, SQLType targetSqlType) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (targetSqlType instanceof MysqlType) {
                 ((PreparedQuery) this.query).getQueryBindings().setObject(getCoreParameterIndex(parameterIndex), parameterObj, (MysqlType) targetSqlType, -1);
             } else {
                 setObject(parameterIndex, parameterObj, targetSqlType.getVendorTypeNumber());
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setObject(int parameterIndex, Object parameterObj, int targetSqlType, int scale) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             try {
                 ((PreparedQuery) this.query).getQueryBindings().setObject(getCoreParameterIndex(parameterIndex), parameterObj,
                         MysqlType.getByJdbcType(targetSqlType), scale);
@@ -1667,17 +1922,23 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
                 throw SQLError.createSQLFeatureNotSupportedException(Messages.getString("Statement.UnsupportedSQLType") + JDBCType.valueOf(targetSqlType),
                         MysqlErrorNumbers.SQL_STATE_DRIVER_NOT_CAPABLE, this.exceptionInterceptor);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (targetSqlType instanceof MysqlType) {
                 ((PreparedQuery) this.query).getQueryBindings().setObject(getCoreParameterIndex(parameterIndex), x, (MysqlType) targetSqlType, scaleOrLength);
             } else {
                 setObject(parameterIndex, x, targetSqlType.getVendorTypeNumber(), scaleOrLength);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1693,8 +1954,12 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
     @Override
     public void setShort(int parameterIndex, short x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setShort(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1710,36 +1975,56 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
 
     @Override
     public void setString(int parameterIndex, String x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setString(getCoreParameterIndex(parameterIndex), x);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setTime(int parameterIndex, Time x) throws java.sql.SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setTime(getCoreParameterIndex(parameterIndex), x, null);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setTime(int parameterIndex, java.sql.Time x, Calendar cal) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setTime(getCoreParameterIndex(parameterIndex), x, cal);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setTimestamp(int parameterIndex, Timestamp x) throws java.sql.SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setTimestamp(getCoreParameterIndex(parameterIndex), x, null, null, MysqlType.TIMESTAMP);
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setTimestamp(int parameterIndex, java.sql.Timestamp x, Calendar cal) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             ((PreparedQuery) this.query).getQueryBindings().setTimestamp(getCoreParameterIndex(parameterIndex), x, cal, null, MysqlType.TIMESTAMP);
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionWrapper.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionWrapper.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.mysql.cj.Messages;
 import com.mysql.cj.MysqlConnection;
@@ -886,7 +887,7 @@ public class ConnectionWrapper extends WrapperBase implements JdbcConnection {
     }
 
     @Override
-    public Object getConnectionMutex() {
+    public ReentrantLock getConnectionMutex() {
         return this.mc.getConnectionMutex();
     }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ha/MultiHostMySQLConnection.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ha/MultiHostMySQLConnection.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.mysql.cj.Messages;
 import com.mysql.cj.ServerVersion;
@@ -642,7 +643,7 @@ public class MultiHostMySQLConnection implements JdbcConnection {
     }
 
     @Override
-    public Object getConnectionMutex() {
+    public ReentrantLock getConnectionMutex() {
         return getActiveMySQLConnection().getConnectionMutex();
     }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/result/ResultSetImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/result/ResultSetImpl.java
@@ -64,6 +64,7 @@ import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.mysql.cj.Messages;
 import com.mysql.cj.MysqlType;
@@ -328,7 +329,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public void initializeWithMetadata() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             initRowsWithMetadata();
 
             if (this.useUsageAdvisor) {
@@ -365,12 +368,16 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
                 this.session.getProtocol().getMetricsHolder().reportNumberOfTablesAccessed(tableNamesSet.size());
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean absolute(int row) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
@@ -418,12 +425,16 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             setRowPositionValidity();
 
             return b;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void afterLast() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
@@ -439,12 +450,16 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             }
 
             setRowPositionValidity();
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void beforeFirst() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
@@ -462,6 +477,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             this.thisRow = null;
 
             setRowPositionValidity();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -499,7 +516,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
      *             if the index is out of bounds
      */
     protected final void checkColumnBounds(int columnIndex) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if ((columnIndex < 1)) {
                 throw SQLError.createSQLException(
                         Messages.getString("ResultSet.Column_Index_out_of_range_low",
@@ -515,6 +534,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             if (this.useUsageAdvisor) {
                 this.columnUsed[columnIndex - 1] = true;
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -554,8 +575,12 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public void clearWarnings() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             this.warningChain = null;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -577,7 +602,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public int findColumn(String columnName) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             int index = this.columnDefinition.findColumn(columnName, this.useColumnNamesInFindColumn, 1);
 
             if (index == -1) {
@@ -587,12 +614,16 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             }
 
             return index;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean first() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
@@ -614,6 +645,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             setRowPositionValidity();
 
             return b;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1080,23 +1113,35 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public int getFetchDirection() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             return this.fetchDirection;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public int getFetchSize() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             return this.fetchSize;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public char getFirstCharOfQuery() {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 return this.firstCharOfQuery;
+            } finally {
+                lock.unlock();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e); // FIXME: Need to evolve interface
@@ -1293,7 +1338,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             throw SQLError.createSQLException("Type parameter can not be null", MysqlErrorNumbers.SQL_STATE_ILLEGAL_ARGUMENT, getExceptionInterceptor());
         }
 
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (type.equals(String.class)) {
                 return (T) getString(columnIndex);
 
@@ -1428,6 +1475,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
             throw SQLError.createSQLException("Conversion not supported for type " + type.getName(), MysqlErrorNumbers.SQL_STATE_ILLEGAL_ARGUMENT,
                     getExceptionInterceptor());
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1624,12 +1673,16 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
     @Override
     public java.sql.Statement getStatement() throws SQLException {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 if (this.wrapperStatement != null) {
                     return this.wrapperStatement;
                 }
 
                 return this.owningStatement;
+            } finally {
+                lock.unlock();
             }
 
         } catch (SQLException sqlEx) {
@@ -1692,8 +1745,12 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public java.sql.SQLWarning getWarnings() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             return this.warningChain;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1704,48 +1761,64 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public boolean isAfterLast() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
             }
             return this.rowData.isAfterLast();
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean isBeforeFirst() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
             }
 
             return this.rowData.isBeforeFirst();
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean isFirst() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
             }
 
             return this.rowData.isFirst();
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean isLast() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
             }
 
             return this.rowData.isLast();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1762,7 +1835,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public boolean last() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
@@ -1784,6 +1859,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             setRowPositionValidity();
 
             return b;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1799,7 +1876,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public boolean next() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
@@ -1825,6 +1904,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             setRowPositionValidity();
 
             return b;
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1842,7 +1923,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
      *                if a database access error occurs
      */
     public boolean prev() throws java.sql.SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
 
             int rowIndex = this.rowData.getPosition();
 
@@ -1867,12 +1950,16 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             setRowPositionValidity();
 
             return b;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public boolean previous() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
@@ -1883,6 +1970,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             }
 
             return prev();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1894,7 +1983,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             return; // already closed
         }
 
-        synchronized (locallyScopedConn.getConnectionMutex()) {
+        ReentrantLock lock = locallyScopedConn.getConnectionMutex();
+        lock.lock();
+        try {
             // additional check in case ResultSet was closed while current thread was waiting for lock
             if (this.isClosed) {
                 return;
@@ -1984,6 +2075,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
                     throw exceptionDuringClose;
                 }
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1999,7 +2092,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public boolean relative(int rows) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!hasRows()) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.ResultSet_is_from_UPDATE._No_Data_115"),
                         MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
@@ -2021,6 +2116,8 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
             setRowPositionValidity();
 
             return (!this.rowData.isAfterLast() && !this.rowData.isBeforeFirst());
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -2041,7 +2138,9 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
     @Override
     public void setFetchDirection(int direction) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if ((direction != FETCH_FORWARD) && (direction != FETCH_REVERSE) && (direction != FETCH_UNKNOWN)) {
                 throw SQLError.createSQLException(Messages.getString("ResultSet.Illegal_value_for_fetch_direction_64"),
                         MysqlErrorNumbers.SQL_STATE_ILLEGAL_ARGUMENT, getExceptionInterceptor());
@@ -2049,30 +2148,40 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
 
             if (isStrictlyForwardOnly() && direction != FETCH_FORWARD) {
                 String constName = direction == ResultSet.FETCH_REVERSE ? "ResultSet.FETCH_REVERSE" : "ResultSet.FETCH_UNKNOWN";
-                throw ExceptionFactory.createException(Messages.getString("ResultSet.Unacceptable_value_for_fetch_direction", new Object[] { constName }));
+                throw ExceptionFactory.createException(Messages.getString("ResultSet.Unacceptable_value_for_fetch_direction", new Object[]{constName}));
             }
 
             this.fetchDirection = direction;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setFetchSize(int rows) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (rows < 0) { /* || rows > getMaxRows() */
                 throw SQLError.createSQLException(Messages.getString("ResultSet.Value_must_be_between_0_and_getMaxRows()_66"),
                         MysqlErrorNumbers.SQL_STATE_ILLEGAL_ARGUMENT, getExceptionInterceptor());
             }
 
             this.fetchSize = rows;
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void setFirstCharOfQuery(char c) {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 this.firstCharOfQuery = c;
+            } finally {
+                lock.unlock();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e); // FIXME: Need to evolve public interface
@@ -2082,8 +2191,12 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
     @Override
     public void setOwningStatement(JdbcStatement owningStatement) {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 this.owningStatement = (StatementImpl) owningStatement;
+            } finally {
+                lock.unlock();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e); // FIXME: Need to evolve public interface
@@ -2098,8 +2211,12 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
      */
     public synchronized void setResultSetConcurrency(int concurrencyFlag) {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 this.resultSetConcurrency = concurrencyFlag;
+            } finally {
+                lock.unlock();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e); // TODO: FIXME: Need to evolve public interface
@@ -2115,8 +2232,12 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
      */
     public synchronized void setResultSetType(int typeFlag) {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 this.resultSetType = typeFlag;
+            } finally {
+                lock.unlock();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e); // TODO: FIXME: Need to evolve public interface
@@ -2131,8 +2252,12 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
      */
     public void setServerInfo(String info) {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 this.serverInfo = info;
+            } finally {
+                lock.unlock();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e); // TODO: FIXME: Need to evolve public interface
@@ -2142,8 +2267,12 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
     @Override
     public synchronized void setStatementUsedForFetchingRows(JdbcPreparedStatement stmt) {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 this.statementUsedForFetchingRows = stmt;
+            } finally {
+                lock.unlock();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e); // TODO: FIXME: Need to evolve public interface
@@ -2153,8 +2282,12 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
     @Override
     public synchronized void setWrapperStatement(java.sql.Statement wrapperStatement) {
         try {
-            synchronized (checkClosed().getConnectionMutex()) {
+            ReentrantLock lock = checkClosed().getConnectionMutex();
+            lock.lock();
+            try {
                 this.wrapperStatement = wrapperStatement;
+            } finally {
+                lock.unlock();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e); // TODO: FIXME: Need to evolve public interface
@@ -2736,7 +2869,7 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
     }
 
     @Override
-    public Object getSyncMutex() {
+    public ReentrantLock getSyncMutex() {
         return this.connection != null ? this.connection.getConnectionMutex() : null;
     }
 

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/result/UpdatableResultSet.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/result/UpdatableResultSet.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.mysql.cj.Messages;
 import com.mysql.cj.MysqlType;
@@ -393,7 +394,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void deleteRow() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.isUpdatable) {
                 throw new NotUpdatable(this.notUpdatableReason);
             }
@@ -428,6 +431,8 @@ public class UpdatableResultSet extends ResultSetImpl {
             this.rowData.remove();
 
             prev(); // position on previous row - Bug#27431
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -713,8 +718,12 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public int getConcurrency() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             return (this.isUpdatable ? CONCUR_UPDATABLE : CONCUR_READ_ONLY);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -728,7 +737,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void insertRow() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 throw SQLError.createSQLException(Messages.getString("UpdatableResultSet.7"), getExceptionInterceptor());
             }
@@ -758,6 +769,8 @@ public class UpdatableResultSet extends ResultSetImpl {
 
             this.rowData.addRow(resultSetRow);
             resetInserter();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -799,7 +812,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void moveToCurrentRow() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.isUpdatable) {
                 throw new NotUpdatable(this.notUpdatableReason);
             }
@@ -808,12 +823,16 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.onInsertRow = false;
                 this.thisRow = this.savedCurrentRow;
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void moveToInsertRow() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.isUpdatable) {
                 throw new NotUpdatable(this.notUpdatableReason);
             }
@@ -881,6 +900,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                     }
                 }
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -926,7 +947,9 @@ public class UpdatableResultSet extends ResultSetImpl {
             return;
         }
 
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             SQLException sqlEx = null;
 
             if (this.useUsageAdvisor) {
@@ -973,12 +996,16 @@ public class UpdatableResultSet extends ResultSetImpl {
             if (sqlEx != null) {
                 throw sqlEx;
             }
+        } finally {
+            lock.unlock();
         }
     }
 
     @Override
     public void refreshRow() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (isStrictlyForwardOnly()) {
                 throw ExceptionFactory.createException(Messages.getString("ResultSet.ForwardOnly"));
             }
@@ -998,6 +1025,8 @@ public class UpdatableResultSet extends ResultSetImpl {
             }
 
             refreshRow(this.updater, this.thisRow);
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1167,7 +1196,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateRow() throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.isUpdatable) {
                 throw new NotUpdatable(this.notUpdatableReason);
             }
@@ -1182,6 +1213,8 @@ public class UpdatableResultSet extends ResultSetImpl {
 
             // fixes calling updateRow() and then doing more updates on same row...
             syncUpdate();
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1197,7 +1230,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateAsciiStream(int columnIndex, java.io.InputStream x, int length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1209,6 +1244,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setAsciiStream(columnIndex, x, length);
                 this.thisRow.setBytes(columnIndex - 1, STREAM_DATA_MARKER);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1219,7 +1256,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateBigDecimal(int columnIndex, BigDecimal x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1231,6 +1270,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setBigDecimal(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, x == null ? null : StringUtils.getBytes(x.toString()));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1241,7 +1282,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateBinaryStream(int columnIndex, java.io.InputStream x, int length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1253,6 +1296,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setBinaryStream(columnIndex, x, length);
                 this.thisRow.setBytes(columnIndex - 1, x == null ? null : STREAM_DATA_MARKER);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1263,7 +1308,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateBlob(int columnIndex, java.sql.Blob blob) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1275,6 +1322,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setBlob(columnIndex, blob);
                 this.thisRow.setBytes(columnIndex - 1, blob == null ? null : STREAM_DATA_MARKER);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1285,7 +1334,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateBoolean(int columnIndex, boolean x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1297,6 +1348,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setBoolean(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1307,7 +1360,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateByte(int columnIndex, byte x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1319,6 +1374,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setByte(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1329,7 +1386,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateBytes(int columnIndex, byte[] x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1341,6 +1400,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setBytes(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, x);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1351,7 +1412,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateCharacterStream(int columnIndex, java.io.Reader x, int length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1363,6 +1426,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setCharacterStream(columnIndex, x, length);
                 this.thisRow.setBytes(columnIndex - 1, x == null ? null : STREAM_DATA_MARKER);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1373,12 +1438,16 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateClob(int columnIndex, java.sql.Clob clob) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (clob == null) {
                 updateNull(columnIndex);
             } else {
                 updateCharacterStream(columnIndex, clob.getCharacterStream(), (int) clob.length());
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1389,7 +1458,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateDate(int columnIndex, java.sql.Date x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1401,6 +1472,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setDate(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1411,7 +1484,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateDouble(int columnIndex, double x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1423,6 +1498,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setDouble(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1433,7 +1510,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateFloat(int columnIndex, float x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1445,6 +1524,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setFloat(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1455,7 +1536,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateInt(int columnIndex, int x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1467,6 +1550,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setInt(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1477,7 +1562,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateLong(int columnIndex, long x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1489,6 +1576,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setLong(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1499,7 +1588,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateNull(int columnIndex) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1511,6 +1602,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setNull(columnIndex, 0);
                 this.thisRow.setBytes(columnIndex - 1, null);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1575,7 +1668,9 @@ public class UpdatableResultSet extends ResultSetImpl {
      *             if an error occurs
      */
     protected void updateObjectInternal(int columnIndex, Object x, SQLType targetType, int scaleOrLength) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1596,6 +1691,8 @@ public class UpdatableResultSet extends ResultSetImpl {
 
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1626,7 +1723,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateShort(int columnIndex, short x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1638,6 +1737,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setShort(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1648,7 +1749,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateString(int columnIndex, String x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1660,6 +1763,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setString(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, x == null ? null : StringUtils.getBytes(x, this.charEncoding));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1670,7 +1775,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateTime(int columnIndex, java.sql.Time x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1682,6 +1789,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setTime(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1692,7 +1801,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateTimestamp(int columnIndex, java.sql.Timestamp x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             if (!this.onInsertRow) {
                 if (!this.doingUpdates) {
                     this.doingUpdates = true;
@@ -1704,6 +1815,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setTimestamp(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, this.inserter.getBytesRepresentation(columnIndex));
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1919,7 +2032,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateNCharacterStream(int columnIndex, Reader x, long length) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             String fieldEncoding = this.getMetadata().getFields()[columnIndex - 1].getEncoding();
             if (fieldEncoding == null || !fieldEncoding.equals("UTF-8")) {
                 throw new SQLException(Messages.getString("ResultSet.16"));
@@ -1936,6 +2051,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setNCharacterStream(columnIndex, x, length);
                 this.thisRow.setBytes(columnIndex - 1, x == null ? null : STREAM_DATA_MARKER);
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -1974,7 +2091,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateNClob(int columnIndex, java.sql.NClob nClob) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             String fieldEncoding = this.getMetadata().getFields()[columnIndex - 1].getEncoding();
             if (fieldEncoding == null || !fieldEncoding.equals("UTF-8")) {
                 throw new SQLException(Messages.getString("ResultSet.17"));
@@ -1985,6 +2104,8 @@ public class UpdatableResultSet extends ResultSetImpl {
             } else {
                 updateNCharacterStream(columnIndex, nClob.getCharacterStream(), (int) nClob.length());
             }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -2005,7 +2126,9 @@ public class UpdatableResultSet extends ResultSetImpl {
 
     @Override
     public void updateNString(int columnIndex, String x) throws SQLException {
-        synchronized (checkClosed().getConnectionMutex()) {
+        ReentrantLock lock = checkClosed().getConnectionMutex();
+        lock.lock();
+        try {
             String fieldEncoding = this.getMetadata().getFields()[columnIndex - 1].getEncoding();
             if (fieldEncoding == null || !fieldEncoding.equals("UTF-8")) {
                 throw new SQLException(Messages.getString("ResultSet.18"));
@@ -2022,6 +2145,8 @@ public class UpdatableResultSet extends ResultSetImpl {
                 this.inserter.setNString(columnIndex, x);
                 this.thisRow.setBytes(columnIndex - 1, x == null ? null : StringUtils.getBytes(x, fieldEncoding));
             }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/src/test/java/testsuite/regression/DataSourceRegressionTest.java
+++ b/src/test/java/testsuite/regression/DataSourceRegressionTest.java
@@ -497,7 +497,7 @@ public class DataSourceRegressionTest extends BaseTestCase {
             final XAConnection xaConn = myDs.getXAConnection();
             final XAResource xaRes = xaConn.getXAResource();
             final Connection dbConn = xaConn.getConnection();
-            final long connId = ((MysqlConnection) ((MysqlConnection) dbConn).getConnectionMutex()).getSession().getThreadId();
+            final long connId = ((MysqlConnection) dbConn).getSession().getThreadId();
 
             xaRes.start(xid, XAResource.TMNOFLAGS);
             xaRes.end(xid, XAResource.TMSUCCESS);

--- a/src/test/java/testsuite/regression/PooledConnectionRegressionTest.java
+++ b/src/test/java/testsuite/regression/PooledConnectionRegressionTest.java
@@ -46,6 +46,7 @@ import java.sql.SQLNonTransientConnectionException;
 import java.sql.Statement;
 import java.util.Properties;
 import java.util.concurrent.Callable;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.sql.ConnectionEvent;
 import javax.sql.ConnectionEventListener;
@@ -500,7 +501,7 @@ public final class PooledConnectionRegressionTest extends BaseTestCase {
         cw.setStatementComment("Test comment");
         assertNotEquals(((JdbcConnection) this.conn).getStatementComment(), cw.getStatementComment());
 
-        assertEquals(ConnectionImpl.class, cw.getConnectionMutex().getClass());
+        assertEquals(ReentrantLock.class, cw.getConnectionMutex().getClass());
         assertNull(cw.getExceptionInterceptor());
         assertEquals(((JdbcConnection) this.conn).getNetworkTimeout(), cw.getNetworkTimeout());
         assertEquals(((JdbcConnection) this.conn).getTypeMap(), cw.getTypeMap());
@@ -880,7 +881,7 @@ public final class PooledConnectionRegressionTest extends BaseTestCase {
             }
         });
 
-        assertEquals(ConnectionImpl.class, cw.getConnectionMutex().getClass());
+        assertEquals(ReentrantLock.class, cw.getConnectionMutex().getClass());
         assertNull(cw.getExceptionInterceptor());
         assertEquals(((JdbcConnection) this.conn).getNetworkTimeout(), cw.getNetworkTimeout());
         assertThrows(SQLNonTransientConnectionException.class, "Logical handle no longer valid", new Callable<Void>() {
@@ -1336,7 +1337,7 @@ public final class PooledConnectionRegressionTest extends BaseTestCase {
                 return null;
             }
         });
-        assertEquals(ConnectionImpl.class, cw.getConnectionMutex().getClass());
+        assertEquals(ReentrantLock.class, cw.getConnectionMutex().getClass());
         assertNull(cw.getExceptionInterceptor());
 
         String comment = cw.getStatementComment();

--- a/src/test/java/testsuite/regression/StatementRegressionTest.java
+++ b/src/test/java/testsuite/regression/StatementRegressionTest.java
@@ -102,6 +102,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
@@ -4569,7 +4570,7 @@ public class StatementRegressionTest extends BaseTestCase {
             }
 
             @Override
-            public Object getSyncMutex() {
+            public ReentrantLock getSyncMutex() {
                 return null;
             }
         };


### PR DESCRIPTION
Replace connectionMutex and synchronized blocks with a ReentrantLock. The synchronized blocks were removed and replaced by `lock.lock()` and `lock.unlock()`. This avoids that the carrier thread (OS thread) is pinned when running on virtual threads which were introduced as a preview feature in JDK 19.

https://openjdk.org/jeps/425
`There are two scenarios in which a virtual thread cannot be unmounted during blocking operations because it is pinned to its carrier:
 
 When it executes code inside a synchronized block or method, or
 When it executes a native method or a foreign function.`

This is a PR for https://bugs.mysql.com/bug.php?id=109346