### PR TITLE
Fix for Bug #108415 - Occasional NPE when server dies

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/AbstractQuery.java
+++ b/src/main/core-impl/java/com/mysql/cj/AbstractQuery.java
@@ -225,7 +225,9 @@ public abstract class AbstractQuery implements Query {
                 throw ExceptionFactory.createException(t.getMessage(), t);
             }
 
-            this.session.getCancelTimer().purge();
+            if (this.session != null) {
+                this.session.getCancelTimer().purge();
+            }
 
             if (checkCancelTimeout) {
                 checkCancelTimeout();


### PR DESCRIPTION
This just adds a very simple null-check guard as suggested in the bug report here:
https://bugs.mysql.com/bug.php?id=108415

I have not added a test as this is a very small change and probably not worth the overhead of a test.  Also, this is my first contribution and I have no idea how to test this.

I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.