### PR TITLE
Only call Messages.getString(...) when it's needed (when the SQLException is thrown)

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/result/ResultSetImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/result/ResultSetImpl.java
@@ -529,26 +529,26 @@ public class ResultSetImpl extends NativeResultset implements ResultSetInternalM
         checkClosed();
 
         if (!this.onValidRow) {
-            throw SQLError.createSQLException(this.invalidRowReason, MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
+            throw SQLError.createSQLException(Messages.getString(this.invalidRowReasonMessageKey), MysqlErrorNumbers.SQL_STATE_GENERAL_ERROR, getExceptionInterceptor());
         }
     }
 
     private boolean onValidRow = false;
-    private String invalidRowReason = null;
+    private String invalidRowReasonMessageKey = null;
 
-    private void setRowPositionValidity() throws SQLException {
+    private void setRowPositionValidity() {
         if (!this.rowData.isDynamic() && (this.rowData.size() == 0)) {
-            this.invalidRowReason = Messages.getString("ResultSet.Illegal_operation_on_empty_result_set");
+            this.invalidRowReasonMessageKey = "ResultSet.Illegal_operation_on_empty_result_set";
             this.onValidRow = false;
         } else if (this.rowData.isBeforeFirst()) {
-            this.invalidRowReason = Messages.getString("ResultSet.Before_start_of_result_set_146");
+            this.invalidRowReasonMessageKey = "ResultSet.Before_start_of_result_set_146";
             this.onValidRow = false;
         } else if (this.rowData.isAfterLast()) {
-            this.invalidRowReason = Messages.getString("ResultSet.After_end_of_result_set_148");
+            this.invalidRowReasonMessageKey = "ResultSet.After_end_of_result_set_148";
             this.onValidRow = false;
         } else {
             this.onValidRow = true;
-            this.invalidRowReason = null;
+            this.invalidRowReasonMessageKey = null;
         }
     }
 


### PR DESCRIPTION
This PR defers calling Messages.getString(...) to the moment an SQLException needs to be thrown. This avoids loading the message from the resourcebundle and the subsequent String formatting and saves some wasted allocations in the case the calling code handles ResultSets correctly (checking if the resultset is empty or has no more rows).