### PR TITLE
Update SyntaxRegressionTest.java

### DIFF
--- a/src/test/java/testsuite/regression/SyntaxRegressionTest.java
+++ b/src/test/java/testsuite/regression/SyntaxRegressionTest.java
@@ -1301,7 +1301,6 @@ public class SyntaxRegressionTest extends BaseTestCase {
         }
     }
 
-    @Test
     private void testCreateTablespaceCheckTablespaces(int expectedTsCount) throws Exception {
         if (versionMeetsMinimum(8, 0, 3)) {
             this.rs = this.stmt.executeQuery("SELECT COUNT(*) FROM information_schema.innodb_tablespaces WHERE name LIKE 'testTs_'");
@@ -1312,7 +1311,6 @@ public class SyntaxRegressionTest extends BaseTestCase {
         assertEquals(expectedTsCount, this.rs.getInt(1));
     }
 
-    @Test
     private void testCreateTablespaceCheckTables(String tablespace, int expectedTblCount) throws Exception {
         if (versionMeetsMinimum(8, 0, 3)) {
             this.rs = this.stmt.executeQuery("SELECT COUNT(*) FROM information_schema.innodb_tables a, information_schema.innodb_tablespaces b "
@@ -1371,7 +1369,6 @@ public class SyntaxRegressionTest extends BaseTestCase {
         testSetMergeThresholdIndices(tableMergeThreshold, keyMergeThresholds);
     }
 
-    @Test
     private void testSetMergeThresholdIndices(int defaultMergeThreshold, Map<String, Integer> keyMergeThresholds) throws Exception {
         boolean dbMapsToSchema = ((JdbcConnection) this.conn).getPropertySet().<DatabaseTerm>getEnumProperty(PropertyKey.databaseTerm)
                 .getValue() == DatabaseTerm.SCHEMA;

--- a/src/test/java/testsuite/regression/SyntaxRegressionTest.java
+++ b/src/test/java/testsuite/regression/SyntaxRegressionTest.java
@@ -1068,7 +1068,6 @@ public class SyntaxRegressionTest extends BaseTestCase {
         testJsonTypeCheckFunction("SELECT JSON_VALID('{\"a\": 1}')", "1");
     }
 
-    @Test
     private void testJsonTypeCheckFunction(String sql, String expectedResult) throws Exception {
         this.rs = this.stmt.executeQuery(sql);
         assertTrue(this.rs.next());

--- a/src/test/java/testsuite/simple/StatementsTest.java
+++ b/src/test/java/testsuite/simple/StatementsTest.java
@@ -215,7 +215,6 @@ public class StatementsTest extends BaseTestCase {
         sspsConn.close();
     }
 
-    @Test
     private void testBinaryResultSetNumericTypesInternal(Connection con) throws Exception {
         /*
          * TINYINT 1 -128 127 SMALLINT 2 -32768 32767 MEDIUMINT 3 -8388608


### PR DESCRIPTION
Some test methods are private, by default JUnit5 ignores private methods with @Test annotation. 
So @Test is unnecesary there. References:
https://rules.sonarsource.com/java/tag/junit/RSPEC-5810