### PR TITLE
Consider the Time.getTime() could be negative

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/util/TimeUtil.java
+++ b/src/main/core-api/java/com/mysql/cj/util/TimeUtil.java
@@ -357,7 +357,7 @@ public class TimeUtil {
     }
 
     public static Boolean hasFractionalSeconds(Time t) {
-        return t.getTime() % 1000 > 0;
+        return t.getTime() % 1000 != 0;
     }
 
     /**


### PR DESCRIPTION
If your system timezone has a positive offset, and the time that java.sql.Time represented is less than the offset, you can get a negative epochMillis from the Time object.