### PR TITLE
Replace StringBuffer with StringBuilder in ValueEncoders

### DIFF
--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/InstantValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/InstantValueEncoder.java
@@ -76,7 +76,7 @@ public class InstantValueEncoder extends AbstractValueEncoder {
                                 .atZoneSameInstant(this.serverSession.getDefaultTimeZone().toZoneId()).toLocalDateTime()),
                         binding.getField(), binding.keepOrigNanos());
 
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
 
                 buf.append(TimeUtil.getSimpleDateFormat(null, "''yyyy-MM-dd HH:mm:ss",
                         binding.getMysqlType() == MysqlType.TIMESTAMP && this.preserveInstants.getValue() ? this.serverSession.getSessionTimeZone()

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/OffsetDateTimeValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/OffsetDateTimeValueEncoder.java
@@ -75,7 +75,7 @@ public class OffsetDateTimeValueEncoder extends AbstractValueEncoder {
                                 ((OffsetDateTime) binding.getValue()).atZoneSameInstant(this.serverSession.getDefaultTimeZone().toZoneId()).toLocalDateTime()),
                         binding.getField(), binding.keepOrigNanos());
 
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
 
                 buf.append(TimeUtil.getSimpleDateFormat(null, "''yyyy-MM-dd HH:mm:ss",
                         binding.getMysqlType() == MysqlType.TIMESTAMP && this.preserveInstants.getValue() ? this.serverSession.getSessionTimeZone()

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/SqlTimeValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/SqlTimeValueEncoder.java
@@ -87,7 +87,7 @@ public class SqlTimeValueEncoder extends AbstractValueEncoder {
                     ts = TimeUtil.truncateFractionalSeconds(ts);
                 }
 
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 buf.append(binding.getCalendar() != null ? TimeUtil.getSimpleDateFormat("''yyyy-MM-dd HH:mm:ss", binding.getCalendar()).format(x)
                         : TimeUtil.getSimpleDateFormat(null, "''yyyy-MM-dd HH:mm:ss", this.serverSession.getDefaultTimeZone()).format(x));
                 if (this.serverSession.getCapabilities().serverSupportsFracSecs() && ts.getNanos() > 0) {

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/SqlTimestampValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/SqlTimestampValueEncoder.java
@@ -75,7 +75,7 @@ public class SqlTimestampValueEncoder extends AbstractValueEncoder {
             case TEXT:
             case MEDIUMTEXT:
             case LONGTEXT:
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
 
                 if (binding.getCalendar() != null) {
                     buf.append(TimeUtil.getSimpleDateFormat("''yyyy-MM-dd HH:mm:ss", binding.getCalendar()).format(x));
@@ -157,7 +157,7 @@ public class SqlTimestampValueEncoder extends AbstractValueEncoder {
             case TEXT:
             case MEDIUMTEXT:
             case LONGTEXT:
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
 
                 if (binding.getCalendar() != null) {
                     buf.append(TimeUtil.getSimpleDateFormat("yyyy-MM-dd HH:mm:ss", binding.getCalendar()).format(x));

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/UtilCalendarValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/UtilCalendarValueEncoder.java
@@ -65,7 +65,7 @@ public class UtilCalendarValueEncoder extends AbstractValueEncoder {
             case TIMESTAMP:
                 Timestamp ts = adjustTimestamp(new java.sql.Timestamp(((Calendar) binding.getValue()).getTimeInMillis()), binding.getField(),
                         binding.keepOrigNanos());
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 if (binding.getCalendar() != null) {
                     buf.append(TimeUtil.getSimpleDateFormat("''yyyy-MM-dd HH:mm:ss", binding.getCalendar()).format(x));
                 } else {

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/UtilDateValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/UtilDateValueEncoder.java
@@ -77,7 +77,7 @@ public class UtilDateValueEncoder extends AbstractValueEncoder {
             case TEXT:
             case MEDIUMTEXT:
             case LONGTEXT:
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
 
                 if (binding.getCalendar() != null) {
                     buf.append(TimeUtil.getSimpleDateFormat("''yyyy-MM-dd HH:mm:ss", binding.getCalendar()).format(x));
@@ -161,7 +161,7 @@ public class UtilDateValueEncoder extends AbstractValueEncoder {
             case TEXT:
             case MEDIUMTEXT:
             case LONGTEXT:
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
 
                 if (binding.getCalendar() != null) {
                     buf.append(TimeUtil.getSimpleDateFormat("yyyy-MM-dd HH:mm:ss", binding.getCalendar()).format(x));

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/ZonedDateTimeValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/ZonedDateTimeValueEncoder.java
@@ -75,7 +75,7 @@ public class ZonedDateTimeValueEncoder extends AbstractValueEncoder {
                                 ((ZonedDateTime) binding.getValue()).withZoneSameInstant(this.serverSession.getDefaultTimeZone().toZoneId()).toLocalDateTime()),
                         binding.getField(), binding.keepOrigNanos());
 
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
 
                 buf.append(TimeUtil.getSimpleDateFormat(null, "''yyyy-MM-dd HH:mm:ss",
                         binding.getMysqlType() == MysqlType.TIMESTAMP && this.preserveInstants.getValue() ? this.serverSession.getSessionTimeZone()


### PR DESCRIPTION
This PR replaces all `StringBuffer`s in implementations of `ValueEncoder` with `StringBuilder`. In each case, the `StringBuffer` is currently used in local scope in a single thread, which does not require the synchronization that is performed by `StringBuffer`.