### PR TITLE
make trustStorePassword be null if this.trustStoreSettings.keyStorePassword is null

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
+++ b/src/main/core-impl/java/com/mysql/cj/protocol/ExportControlled.java
@@ -547,7 +547,7 @@ public class ExportControlled {
                 if (this.verifyServerCertificate) {
                     KeyStore trustKeyStore = null;
                     if (!StringUtils.isNullOrEmpty(this.trustStoreSettings.keyStoreUrl) && !StringUtils.isNullOrEmpty(this.trustStoreSettings.keyStoreType)) {
-                        char[] trustStorePassword = this.trustStoreSettings.keyStorePassword == null ? new char[0]
+                        char[] trustStorePassword = this.trustStoreSettings.keyStorePassword == null ? null
                                 : this.trustStoreSettings.keyStorePassword.toCharArray();
                         trustStoreIS = new URL(this.trustStoreSettings.keyStoreUrl).openStream();
                         trustKeyStore = StringUtils.isNullOrEmpty(this.keyStoreProvider) ? KeyStore.getInstance(this.trustStoreSettings.keyStoreType)


### PR DESCRIPTION
Not providing a trust store password (e.g. `-Djavax.net.ssl.trustStorePassword` or `System.setProperty("javax.net.ssl.trustStorePassword", ...)` only means that you don't care about checking the integrity of the trust store before using (reading) it.

The following snippet comes from `sun.security.provider.JavaKeyStore` where this check is performed:

```java
    /*
    * If a password has been provided, we check the keyed digest
    * at the end. If this check fails, the store has been tampered
    * with
    */
    if (password != null) {
      ...
```

This doesn't work in the current implementation of `mysql-connector-j`, where a `null` (not set) password is being translated to `byte[0]` before passed further up the stack.

This PR solves this and makes it so that no password means "do not check the keyed digest", as expected. 