### PR TITLE
Auto-closeable X dev session

### DIFF
--- a/src/main/user-api/java/com/mysql/cj/xdevapi/Session.java
+++ b/src/main/user-api/java/com/mysql/cj/xdevapi/Session.java
@@ -74,7 +74,7 @@ import java.util.List;
  * <p>
  * Users of the CRUD API do not need to escape identifiers. This is true for working with collections and for working with relational tables.
  */
-public interface Session {
+public interface Session extends AutoCloseable {
 
     /**
      * Retrieve the list of Schema objects for which the current user has access.
@@ -152,6 +152,7 @@ public interface Session {
     /**
      * Close this session.
      */
+    @Override
     void close();
 
     /**

--- a/src/test/java/testsuite/x/devapi/AutoCloseableTest.java
+++ b/src/test/java/testsuite/x/devapi/AutoCloseableTest.java
@@ -1,0 +1,43 @@
+package testsuite.x.devapi;
+
+import com.mysql.cj.xdevapi.Session;
+import com.mysql.cj.xdevapi.SessionImpl;
+import com.mysql.cj.xdevapi.SessionFactory;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class AutoCloseableTest {
+    @Test
+    public void testAutoCloseableSession() throws Exception {
+        final SessionFactory testSessionFactory = new SessionFactory();
+        Session session = null;
+        try (Session s = new MockSession()) {
+            session = s;
+            assertTrue(s.isOpen());
+        }
+        assertNotNull(session);
+        assertFalse(session.isOpen());
+    }
+
+    private static class MockSession extends SessionImpl {
+        boolean closed = false;
+
+        public MockSession() {
+        }
+
+        @Override
+        public boolean isOpen() {
+            return !closed;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}


### PR DESCRIPTION
Make XDev API Session autocloseable:
```java
try (Session session =  client.getSession()) {
    Result result = session.getSchema(schema).getCollection(collection)
            .remove("name like :name")
            .bind("name", name)
            .execute();

    res.send("Deleted " + result.getAffectedItemsCount() + " docs.");
}
```