### PR TITLE
Report original sql statements in db.statement span attribute

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/CallableStatement.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/CallableStatement.java
@@ -850,7 +850,7 @@ public class CallableStatement extends ClientPreparedStatement implements java.s
                 String dbOperation = getQueryInfo().getStatementKeyword();
                 span.setAttribute(TelemetryAttribute.DB_NAME, getCurrentDatabase());
                 span.setAttribute(TelemetryAttribute.DB_OPERATION, dbOperation);
-                span.setAttribute(TelemetryAttribute.DB_STATEMENT, dbOperation + TelemetryAttribute.STATEMENT_SUFFIX);
+                span.setAttribute(TelemetryAttribute.DB_STATEMENT, paramInfo.nativeSql);
                 span.setAttribute(TelemetryAttribute.DB_SYSTEM, TelemetryAttribute.DB_SYSTEM_DEFAULT);
                 span.setAttribute(TelemetryAttribute.DB_USER, this.connection.getUser());
                 span.setAttribute(TelemetryAttribute.THREAD_ID, Thread.currentThread().getId());

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ClientPreparedStatement.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ClientPreparedStatement.java
@@ -295,7 +295,7 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
                 String dbOperation = getQueryInfo().getStatementKeyword();
                 span.setAttribute(TelemetryAttribute.DB_NAME, getCurrentDatabase());
                 span.setAttribute(TelemetryAttribute.DB_OPERATION, dbOperation);
-                span.setAttribute(TelemetryAttribute.DB_STATEMENT, dbOperation + TelemetryAttribute.STATEMENT_SUFFIX);
+                span.setAttribute(TelemetryAttribute.DB_STATEMENT, getQueryInfo().getSqlForBatch());
                 span.setAttribute(TelemetryAttribute.DB_SYSTEM, TelemetryAttribute.DB_SYSTEM_DEFAULT);
                 span.setAttribute(TelemetryAttribute.DB_USER, this.connection.getUser());
                 span.setAttribute(TelemetryAttribute.THREAD_ID, Thread.currentThread().getId());
@@ -946,7 +946,7 @@ public class ClientPreparedStatement extends com.mysql.cj.jdbc.StatementImpl imp
                 String dbOperation = getQueryInfo().getStatementKeyword();
                 span.setAttribute(TelemetryAttribute.DB_NAME, getCurrentDatabase());
                 span.setAttribute(TelemetryAttribute.DB_OPERATION, dbOperation);
-                span.setAttribute(TelemetryAttribute.DB_STATEMENT, dbOperation + TelemetryAttribute.STATEMENT_SUFFIX);
+                span.setAttribute(TelemetryAttribute.DB_STATEMENT, getQueryInfo().getSqlForBatch());
                 span.setAttribute(TelemetryAttribute.DB_SYSTEM, TelemetryAttribute.DB_SYSTEM_DEFAULT);
                 span.setAttribute(TelemetryAttribute.DB_USER, this.connection.getUser());
                 span.setAttribute(TelemetryAttribute.THREAD_ID, Thread.currentThread().getId());

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
@@ -1555,7 +1555,7 @@ public class ConnectionImpl implements JdbcConnection, SessionEventListener, Ser
                 String dbOperation = cStmt.getQueryInfo().getStatementKeyword();
                 span.setAttribute(TelemetryAttribute.DB_NAME, getDatabase());
                 span.setAttribute(TelemetryAttribute.DB_OPERATION, dbOperation);
-                span.setAttribute(TelemetryAttribute.DB_STATEMENT, dbOperation + TelemetryAttribute.STATEMENT_SUFFIX);
+                span.setAttribute(TelemetryAttribute.DB_STATEMENT, cStmt.getQueryInfo().getSqlForBatch());
                 span.setAttribute(TelemetryAttribute.DB_SYSTEM, TelemetryAttribute.DB_SYSTEM_DEFAULT);
                 span.setAttribute(TelemetryAttribute.DB_USER, getUser());
                 span.setAttribute(TelemetryAttribute.THREAD_ID, Thread.currentThread().getId());
@@ -1676,7 +1676,7 @@ public class ConnectionImpl implements JdbcConnection, SessionEventListener, Ser
                 String dbOperation = pStmt.getQueryInfo().getStatementKeyword();
                 span.setAttribute(TelemetryAttribute.DB_NAME, getDatabase());
                 span.setAttribute(TelemetryAttribute.DB_OPERATION, dbOperation);
-                span.setAttribute(TelemetryAttribute.DB_STATEMENT, dbOperation + TelemetryAttribute.STATEMENT_SUFFIX);
+                span.setAttribute(TelemetryAttribute.DB_STATEMENT, pStmt.getQueryInfo().getSqlForBatch());
                 span.setAttribute(TelemetryAttribute.DB_SYSTEM, TelemetryAttribute.DB_SYSTEM_DEFAULT);
                 span.setAttribute(TelemetryAttribute.DB_USER, getUser());
                 span.setAttribute(TelemetryAttribute.THREAD_ID, Thread.currentThread().getId());

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/StatementImpl.java
@@ -707,7 +707,7 @@ public class StatementImpl implements JdbcStatement {
                 String dbOperation = QueryInfo.getStatementKeyword(sql, this.session.getServerSession().isNoBackslashEscapesSet());
                 span.setAttribute(TelemetryAttribute.DB_NAME, getCurrentDatabase());
                 span.setAttribute(TelemetryAttribute.DB_OPERATION, dbOperation);
-                span.setAttribute(TelemetryAttribute.DB_STATEMENT, dbOperation + TelemetryAttribute.STATEMENT_SUFFIX);
+                span.setAttribute(TelemetryAttribute.DB_STATEMENT, sql);
                 span.setAttribute(TelemetryAttribute.DB_SYSTEM, TelemetryAttribute.DB_SYSTEM_DEFAULT);
                 span.setAttribute(TelemetryAttribute.DB_USER, this.connection.getUser());
                 span.setAttribute(TelemetryAttribute.THREAD_ID, Thread.currentThread().getId());
@@ -1176,7 +1176,7 @@ public class StatementImpl implements JdbcStatement {
                 String dbOperation = QueryInfo.getStatementKeyword(sql, this.session.getServerSession().isNoBackslashEscapesSet());
                 span.setAttribute(TelemetryAttribute.DB_NAME, getCurrentDatabase());
                 span.setAttribute(TelemetryAttribute.DB_OPERATION, dbOperation);
-                span.setAttribute(TelemetryAttribute.DB_STATEMENT, dbOperation + TelemetryAttribute.STATEMENT_SUFFIX);
+                span.setAttribute(TelemetryAttribute.DB_STATEMENT, sql);
                 span.setAttribute(TelemetryAttribute.DB_SYSTEM, TelemetryAttribute.DB_SYSTEM_DEFAULT);
                 span.setAttribute(TelemetryAttribute.DB_USER, this.connection.getUser());
                 span.setAttribute(TelemetryAttribute.THREAD_ID, Thread.currentThread().getId());
@@ -1353,7 +1353,7 @@ public class StatementImpl implements JdbcStatement {
                 String dbOperation = QueryInfo.getStatementKeyword(sql, this.session.getServerSession().isNoBackslashEscapesSet());
                 span.setAttribute(TelemetryAttribute.DB_NAME, getCurrentDatabase());
                 span.setAttribute(TelemetryAttribute.DB_OPERATION, dbOperation);
-                span.setAttribute(TelemetryAttribute.DB_STATEMENT, dbOperation + TelemetryAttribute.STATEMENT_SUFFIX);
+                span.setAttribute(TelemetryAttribute.DB_STATEMENT, sql);
                 span.setAttribute(TelemetryAttribute.DB_SYSTEM, TelemetryAttribute.DB_SYSTEM_DEFAULT);
                 span.setAttribute(TelemetryAttribute.DB_USER, this.connection.getUser());
                 span.setAttribute(TelemetryAttribute.THREAD_ID, Thread.currentThread().getId());


### PR DESCRIPTION
@fjssilva I'm opening this PR to initiate a discussion.  I see you added OpenTelemetry support to this library - awesome!  I'm curious why the `db.statement` attribute is reported as `{operation} (..)` instead of the raw sql.  I've normally seen this reported as the full sql statement per the [otel specs](https://opentelemetry.io/docs/specs/semconv/attributes-registry/db/).  Do you have security concerns about reporting the full sql?  Customers can always obfuscate or remove this data using an OpenTelemetry collector.

My use case is that I want what today is known as `db.sql.table` (and in the future will probably change to `db.collection.name`).  If the `db.statement` is provided, we can parse the table name out of the sql (choosing the first table if multiple are present).