### PR TITLE
Feature/auto reconnection

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
@@ -325,6 +325,9 @@ public class PropertyDefinitions {
                 new BooleanPropertyDefinition(PropertyKey.dnsSrv, DEFAULT_VALUE_FALSE, RUNTIME_NOT_MODIFIABLE,
                         Messages.getString("ConnectionProperties.dnsSrv"), "8.0.19", CATEGORY_NETWORK, Integer.MIN_VALUE),
 
+                new IntegerPropertyDefinition(PropertyKey.regenerateConnectionTimeout, 0, RUNTIME_MODIFIABLE, 
+                        "Auto reconnection interval", "8.4.0", CATEGORY_NETWORK, 11, 5, Integer.MAX_VALUE),
+                
                 //
                 // CATEGORY_SECURITY
                 //

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyDefinitions.java
@@ -326,7 +326,7 @@ public class PropertyDefinitions {
                         Messages.getString("ConnectionProperties.dnsSrv"), "8.0.19", CATEGORY_NETWORK, Integer.MIN_VALUE),
 
                 new IntegerPropertyDefinition(PropertyKey.regenerateConnectionTimeout, 0, RUNTIME_MODIFIABLE, 
-                        "Auto reconnection interval", "8.4.0", CATEGORY_NETWORK, 11, 5, Integer.MAX_VALUE),
+                        "Auto reconnection interval", "8.4.0", CATEGORY_NETWORK, 11, 0, Integer.MAX_VALUE),
                 
                 //
                 // CATEGORY_SECURITY

--- a/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/PropertyKey.java
@@ -189,6 +189,7 @@ public enum PropertyKey {
     readFromSourceWhenNoReplicas("readFromSourceWhenNoReplicas", "readFromMasterWhenNoSlaves", true), //
     readOnlyPropagatesToServer("readOnlyPropagatesToServer", true), //
     reconnectAtTxEnd("reconnectAtTxEnd", true), //
+    regenerateConnectionTimeout("regenerateConnectionTimeout", true),
     replicationConnectionGroup("replicationConnectionGroup", true), //
     reportMetricsIntervalMillis("reportMetricsIntervalMillis", true), //
     requireSSL("requireSSL", true), //


### PR DESCRIPTION
The purpose of the PR is to add logic to allow automatic reconnection after a certain period of time, before executing a query. 

This strategy avoids reusing a connection that has been idle for a long time and add support for AWS RDS proxy and AWS serverless, because for long lived connection the AWS RDS proxy requires that the TCP connection is re-established in 24 hours, otherwise it is dropped with errors:
[https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-managing.html](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-managing.html)

From AWS documentation:
> Client connection max life: RDS Proxy enforces a maximum life of client connections of 24 hours. This value is not configurable. Configure your pool with a maximum connection life less than 24 hours to avoid unexpected client connection drops.
> Aurora Serverless v1 closes connections that are older than 24 hours. Make sure that your connection pool refreshes connections frequently.

A new property 'regenerateConnectionTimeout' has been added to control the time interval that must elapse before performing a reconnection. If the value of the property is zero, no reconnection is performed.