### PR TITLE
[fix] QueryTimeout does not take effect in certain scenarios.

### DIFF
--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeProtocol.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeProtocol.java
@@ -943,7 +943,8 @@ public class NativeProtocol extends AbstractProtocol<NativePacketPayload> implem
             }
 
             // Send query command and sql query string
-            NativePacketPayload resultPacket = sendCommand(queryPacket, false, 0);
+            NativePacketPayload resultPacket = sendCommand(queryPacket, false,
+                    callingQuery.getTimeoutInMillis() <= 0 ? 0 : callingQuery.getTimeoutInMillis());
 
             final long queryEndTime = getCurrentTimeNanosOrMillis();
             final long queryDuration = queryEndTime - queryStartTime;


### PR DESCRIPTION
The problem arises when the client fails to perceive the release of a connection.