### PR TITLE
Set correct OTel Span name for transaction commits

### DIFF
--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
@@ -808,7 +808,7 @@ public class ConnectionImpl implements JdbcConnection, SessionEventListener, Ser
                     }
                 }
 
-                TelemetrySpan span = this.session.getTelemetryHandler().startSpan(TelemetrySpanName.ROLLBACK);
+                TelemetrySpan span = this.session.getTelemetryHandler().startSpan(TelemetrySpanName.COMMIT);
                 try (TelemetryScope scope = span.makeCurrent()) {
                     span.setAttribute(TelemetryAttribute.DB_NAME, getDatabase());
                     span.setAttribute(TelemetryAttribute.DB_OPERATION, TelemetryAttribute.OPERATION_ROLLBACK);


### PR DESCRIPTION
When collecting tracing information via OpenTelemetry, I saw unexpected `Rollback` spans which I couldn't explain. 
Following the source, it seems it should have indeed been a `Commit` span, so correct that in this PR.

I'm using:
```xml
<dependency>
	<groupId>com.mysql</groupId>
	<artifactId>mysql-connector-j</artifactId>
	<version>8.4.0</version>
</dependency>
```

Notes:
- I just signed the OCA, I believe it's under review currently
- I tried searching for tests, but couldn't find any, so I hope my PR is complete this way
- this PR only addresses the version I use (8.4.0), I hope it can be cherry-picked to other releases as well if necessary