### PR TITLE
Update StringUtils.java

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/util/StringUtils.java
+++ b/src/main/core-api/java/com/mysql/cj/util/StringUtils.java
@@ -1766,7 +1766,11 @@ public class StringUtils {
                     buf.append('\\');
                     break;
                 case '\'':
-                    buf.append('\'');
+                    if (useAnsiQuotedIdentifiers) {
+                        buf.append('\'');
+                    } else {
+                        buf.append('\\');
+                    }
                     buf.append('\'');
                     break;
                 case '"': /* Better safe than sorry */


### PR DESCRIPTION
there is a bug in  non ANSI mode: ' escaped to '' in any cases
should be ' -> \'
btw, the last properly working in 8.0.17 