### PR TITLE
Bug in string escape of single quote

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/util/StringUtils.java
+++ b/src/main/core-api/java/com/mysql/cj/util/StringUtils.java
@@ -1766,11 +1766,7 @@ public class StringUtils {
                     buf.append('\\');
                     break;
                 case '\'':
-                    if (useAnsiQuotedIdentifiers) {
-                        buf.append('\'');
-                    } else {
-                        buf.append('\\');
-                    }
+                    buf.append('\\');
                     buf.append('\'');
                     break;
                 case '"': /* Better safe than sorry */

--- a/src/main/core-api/java/com/mysql/cj/util/StringUtils.java
+++ b/src/main/core-api/java/com/mysql/cj/util/StringUtils.java
@@ -1766,7 +1766,11 @@ public class StringUtils {
                     buf.append('\\');
                     break;
                 case '\'':
-                    buf.append('\'');
+                    if (useAnsiQuotedIdentifiers) {
+                        buf.append('\'');
+                    } else {
+                        buf.append('\\');
+                    }
                     buf.append('\'');
                     break;
                 case '"': /* Better safe than sorry */


### PR DESCRIPTION
According to
https://github.com/mysql/mysql-server/blob/trunk/mysys/charset.cc#L475

\' sholud be escaped to \\\', not \'\'

https://bugs.mysql.com/bug.php?id=115992