### PR TITLE
Fixed for Bug#109339, BIGINT UNSIGNED column fails to accept its maximum supported value

### DIFF
--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NumberValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NumberValueEncoder.java
@@ -56,7 +56,7 @@ public class NumberValueEncoder extends AbstractValueEncoder {
             case INT_UNSIGNED:
             case BIGINT:
             case BIGINT_UNSIGNED:
-                return String.valueOf(x.longValue());
+                return x.toString();
             case FLOAT:
             case FLOAT_UNSIGNED:
                 return StringUtils.fixDecimalExponent(Float.toString(x.floatValue()));

--- a/src/test/java/testsuite/regression/NumbersRegressionTest.java
+++ b/src/test/java/testsuite/regression/NumbersRegressionTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSetMetaData;
@@ -268,6 +269,27 @@ public class NumbersRegressionTest extends BaseTestCase {
             con.close();
 
         } while ((useSPS = !useSPS) || (useCursorFetch = !useCursorFetch));
+    }
+
+    /**
+     * Tests fix for BUG#109339, BIGINT UNSIGNED column fails to accept its maximum supported value.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testBug109339() throws Exception {
+        BigInteger value = new BigInteger("18446744073709551615"); // 2^64-1 - maximum value supported by BIGINT UNSIGNED
+
+        createTable("testBug109339", "(field1 BIGINT UNSIGNED)");
+
+        PreparedStatement ps = this.conn.prepareStatement("INSERT INTO testBug109339 VALUES (?)");
+        ps.setObject(1, value);
+        ps.executeUpdate();
+
+        this.rs = this.conn.prepareStatement("SELECT * FROM testBug109339").executeQuery();
+        this.rs.next();
+
+        assertTrue(this.rs.getObject(1).toString().equals(value.toString()));
     }
 
 }


### PR DESCRIPTION
https://bugs.mysql.com/bug.php?id=109339

----


# Failing Test

I was unable to pass all the tests in my environment, but after reviewing the failed tests, I believe they are unrelated to the changes made in this fix. Could you test this patch in your environment before merging?

| Class                     | Name                                    | Status   |
|---------------------------|-----------------------------------------|----------|
| ConnectionRegressionTest  | testBug12218()                         | Failure  |
| ConnectionRegressionTest  | testBug28150662()                      | Failure  |
| ConnectionRegressionTest  | testBug70785()                         | Failure  |
| ConnectionRegressionTest  | testDefaultPlugin()                    | Failure  |
| ConnectionRegressionTest  | testBug79612()                         | Failure  |
| ConnectionRegressionTest  | testChangeUserNoDb()                   | Failure  |
| ConnectionRegressionTest  | testBug22678872()                      | Failure  |
| ConnectionRegressionTest  | testChangeUser()                       | Failure  |
| ConnectionRegressionTest  | testBug25642021()                      | Failure  |
| StatementRegressionTest   | testBug77368()                         | Failure  |
| ConnectionTest            | testDriverConnectPropertiesPrecedence()| Failure  |
| ConnectionTest            | testIPv6()                             | Failure  |
| ExceptionsTest            | testExceptionsTranslation()            | Failure  |
| MetadataTest              | testGetTablePrivileges()               | Failure  |
| SecureConnectionTest      | testFipsCompliantJsse()                | Failure  |
| SecureConnectionTest      | testKeyStoreProvider()                 | Failure  |
