### PR TITLE
could we remove CJCommunicationsException throw exception directly?

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PropertiesComponent">{}</component>
+</project>

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/ConnectionImpl.java
@@ -2005,8 +2005,6 @@ public class ConnectionImpl implements JdbcConnection, SessionEventListener, Ser
                     this.session.execSQL(null, autoCommitFlag ? "SET autocommit=1" : "SET autocommit=0", -1, null, false, this.nullStatementResultSetFactory,
                             null, false);
                 }
-            } catch (CJCommunicationsException e) {
-                throw e;
             } catch (CJException e) {
                 // Reset to current autocommit value in case of an exception different than a communication exception occurs.
                 this.session.getServerSession().setAutoCommit(isAutoCommit);


### PR DESCRIPTION
When using mysql-connector-java, the server returns a CJCommunicationsException error, causing the AutoCommit value on the client side to be inconsistent with the server side, finally the transaction cannot be rolled back correctly. 

Would we know why does the ConnectionImpl.setAutoCommit() method need to catch CJCommunicationsException separately and throw the exception directly, instead of resetting AutoCommit to the original value and then throwing SQLException like other CJException? and the code as following currenly:

```
    @Override
    public void setAutoCommit(final boolean autoCommitFlag) throws SQLException {  
      ...
        **} catch (CJCommunicationsException e) {
                        throw e;**
        } catch (CJException e) {
            // Reset to current autocommit value in case of an exception different than a communication exception occurs.
            this.session.getServerSession().setAutoCommit(isAutoCommit);
            // Update the stacktrace.
            throw SQLError.createSQLException(e.getMessage(), e.getSQLState(), e.getVendorCode(), e.isTransient(), e, getExceptionInterceptor());
        } finally {
            if (this.autoReconnectForPools.getValue()) {
                this.autoReconnect.setValue(false);
            }
        }
        return;
    }
  }
```

How to repeat or fix:
Maybe a unit test is needed to reproduce this problem, but I haven't found it yet. We want to know if we fix the issue with delete the separate catch of CJCommunicationsException and keep it consistent with all CJException processing logic

    @Override
    public void setAutoCommit(final boolean autoCommitFlag) throws SQLException {  
        ...

            } catch (CJException e) {
                // Reset to current autocommit value in case of an exception different than a communication exception occurs.
                this.session.getServerSession().setAutoCommit(isAutoCommit);
                // Update the stacktrace.
                throw SQLError.createSQLException(e.getMessage(), e.getSQLState(), e.getVendorCode(), e.isTransient(), e, getExceptionInterceptor());
            } finally {
                if (this.autoReconnectForPools.getValue()) {
                    this.autoReconnect.setValue(false);
                }
            }

            return;
        }
    }