### PR TITLE
Optimize BigDecimal zero value handling to reduce memory footprint

### DIFF
--- a/src/main/core-impl/java/com/mysql/cj/result/BigDecimalValueFactory.java
+++ b/src/main/core-impl/java/com/mysql/cj/result/BigDecimalValueFactory.java
@@ -52,6 +52,9 @@ public class BigDecimalValueFactory extends AbstractNumericValueFactory<BigDecim
      * @return result
      */
     private BigDecimal adjustResult(BigDecimal d) {
+        if (d.signum() == 0) {
+            d = BigDecimal.ZERO.setScale(d.scale());
+        }
         if (this.hasScale) {
             try {
                 return d.setScale(this.scale);

--- a/src/test/java/com/mysql/cj/result/BigDecimalValueFactoryTest.java
+++ b/src/test/java/com/mysql/cj/result/BigDecimalValueFactoryTest.java
@@ -22,6 +22,7 @@ package com.mysql.cj.result;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.math.BigDecimal;
 
@@ -103,6 +104,7 @@ public class BigDecimalValueFactoryTest extends CommonAsserts {
         assertEquals(Constants.BIG_DECIMAL_MAX_INTEGER_VALUE, this.vf.createFromBigDecimal(Constants.BIG_DECIMAL_MAX_INTEGER_VALUE));
         assertEquals(Constants.BIG_DECIMAL_NEGATIVE_ONE, this.vf.createFromBigDecimal(Constants.BIG_DECIMAL_NEGATIVE_ONE));
         assertEquals(Constants.BIG_DECIMAL_MIN_INTEGER_VALUE, this.vf.createFromBigDecimal(Constants.BIG_DECIMAL_MIN_INTEGER_VALUE));
+        assertSame(this.vf.createFromBigDecimal(Constants.BIG_DECIMAL_ZERO), this.vf.createFromBigDecimal(Constants.BIG_DECIMAL_ZERO));
     }
 
     @Test


### PR DESCRIPTION
### **What was done:**
When using MySQL JDBC driver to process result sets containing BigDecimal values (including zero values), the application retrieves numeric fields that evaluate to 0 (e.g., SELECT amount FROM orders WHERE amount = 0).


### **What was expected:**
Following the behavior of the Oracle JDBC driver, which reuses the same `BigDecimal` instance for zero values to minimize memory allocation and optimize memory footprint. This ensures consistent reference equality (i.e., `object1 == object2` for zero values) and reduces redundant object creation.


### **What actually happened:**
The MySQL JDBC driver creates a new BigDecimal instance for each zero value encountered in the result set, even when the value is logically identical to BigDecimal.ZERO.