### PR TITLE
Fix Bug #118688	com.mysql.cj.protocol.a.StringValueEncoder#getString does not handle string escaping

### DIFF
--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/StringValueEncoder.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/StringValueEncoder.java
@@ -171,11 +171,9 @@ public class StringValueEncoder extends AbstractValueEncoder {
             case BLOB:
             case MEDIUMBLOB:
             case LONGBLOB:
-                StringBuilder sb = new StringBuilder("'");
-                sb.append(x);
-                sb.append("'");
-                return sb.toString();
+                return StringUtils.toString(getBytes(binding), this.charEncoding.getValue());
             case DATE:
+                StringBuilder sb;
                 Object dt = TimeUtil.parseToDateTimeObject(x, binding.getMysqlType());
                 if (dt instanceof LocalDate) {
                     sb = new StringBuilder("'");

--- a/src/test/java/testsuite/regression/StatementRegressionTest.java
+++ b/src/test/java/testsuite/regression/StatementRegressionTest.java
@@ -14052,4 +14052,12 @@ public class StatementRegressionTest extends BaseTestCase {
         assertTrue(this.stmt.isClosed());
     }
 
+    @Test
+    public  void testBug118688() throws Exception {
+        ClientPreparedStatement preparedStatement = (ClientPreparedStatement) this.conn.prepareStatement("SELECT * FROM test wehre id = ?");
+        preparedStatement.setString(1, "'a'");
+        String sql = ((ClientPreparedQuery) preparedStatement.getQuery()).asSql();
+        assertEquals("SELECT * FROM test wehre id = '''a'''",sql);
+    }
+
 }

--- a/src/test/java/testsuite/regression/StatementRegressionTest.java
+++ b/src/test/java/testsuite/regression/StatementRegressionTest.java
@@ -14053,11 +14053,13 @@ public class StatementRegressionTest extends BaseTestCase {
     }
 
     @Test
-    public  void testBug118688() throws Exception {
+    public void testBug118688() throws Exception {
         ClientPreparedStatement preparedStatement = (ClientPreparedStatement) this.conn.prepareStatement("SELECT * FROM test wehre id = ?");
         preparedStatement.setString(1, "'a'");
         String sql = ((ClientPreparedQuery) preparedStatement.getQuery()).asSql();
-        assertEquals("SELECT * FROM test wehre id = '''a'''",sql);
+        assertEquals("SELECT * FROM test wehre id = '''a'''", sql);
+        preparedStatement.close();
+        assertTrue(preparedStatement.isClosed());
     }
 
 }


### PR DESCRIPTION
Description:
The method `com.mysql.cj.protocol.a.StringValueEncoder#getString` does not escape string values properly, which causes `com.mysql.cj.ClientPreparedQuery#asSql` to generate incorrect SQL. This may lead to invalid SQL syntax or potential security issues.

How to repeat:
```java
 Connection connection = DriverManager.getConnection("jdbc:mysql://127.0.0.1:3306/test", "root", "123456");

        ClientPreparedStatement preparedStatement = (ClientPreparedStatement) connection.prepareStatement("select * from test where id = ?");
        preparedStatement.setString(1, "'a'");
        for (BindValue bindValue : preparedStatement.getQueryBindings().getBindValues()) {
            byte[] byteValue = bindValue.getByteValue();
//            right
            System.out.println(new String(byteValue, StandardCharsets.UTF_8));
        }
        String sql = ((ClientPreparedQuery) preparedStatement.getQuery()).asSql();
        //error
        System.out.println(sql);
```