### PR TITLE
fix Bug #119271: Connector/J fails to accept legacy value zeroDateTimeBehavior=convertToNull on multi-host URLs (failover), but works on

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/conf/ConnectionUrl.java
+++ b/src/main/core-api/java/com/mysql/cj/conf/ConnectionUrl.java
@@ -372,6 +372,11 @@ public abstract class ConnectionUrl implements DatabaseUrlContainer {
         setupPropertiesTransformer();
         expandPropertiesFromConfigFiles(this.properties);
         injectPerTypeProperties(this.properties);
+
+        // Fix protocol dependencies in global properties (e.g., set socketFactory when protocol=PIPE).
+        fixProtocolDependencies(this.properties);
+        // Workaround for zeroDateTimeBehavior=convertToNull hard-coded in NetBeans
+        replaceLegacyPropertyValues(this.properties);
     }
 
     /**

--- a/src/test/java/com/mysql/cj/ConnectionUrlTest.java
+++ b/src/test/java/com/mysql/cj/ConnectionUrlTest.java
@@ -1206,6 +1206,39 @@ public class ConnectionUrlTest {
         }
     }
 
+    @Test
+    public void testReplaceLegacyPropertyValuesInGlobalPropsForMultiHost() throws Exception {
+        // URL-level legacy value
+        String cs1 = "jdbc:mysql://host1:3306,host2:3306/db?zeroDateTimeBehavior=convertToNull";
+        ConnectionUrl url1 = ConnectionUrl.getConnectionUrlInstance(cs1, null);
+        assertEquals(ZeroDatetimeBehavior.CONVERT_TO_NULL.name(),
+                url1.getConnectionArgumentsAsProperties().getProperty(PropertyKey.zeroDateTimeBehavior.getKeyName()));
+        // Info map legacy value
+        String cs2 = "jdbc:mysql://host1:3306,host2:3306/db";
+        Properties p2 = new Properties();
+        p2.setProperty(PropertyKey.zeroDateTimeBehavior.getKeyName(), "convertToNull");
+        ConnectionUrl url2 = ConnectionUrl.getConnectionUrlInstance(cs2, p2);
+        assertEquals(ZeroDatetimeBehavior.CONVERT_TO_NULL.name(),
+                url2.getConnectionArgumentsAsProperties().getProperty(PropertyKey.zeroDateTimeBehavior.getKeyName()));
+        // Mixed: URL has unrelated params, info has legacy value
+        String cs3 = "jdbc:mysql://host1:3306,host2:3306/db?useSSL=false&allowPublicKeyRetrieval=true";
+        Properties p3 = new Properties();
+        p3.setProperty(PropertyKey.zeroDateTimeBehavior.getKeyName(), "convertToNull");
+        ConnectionUrl url3 = ConnectionUrl.getConnectionUrlInstance(cs3, p3);
+        assertEquals(ZeroDatetimeBehavior.CONVERT_TO_NULL.name(),
+                url3.getConnectionArgumentsAsProperties().getProperty(PropertyKey.zeroDateTimeBehavior.getKeyName()));
+    }
+    
+    @Test
+    public void testFixProtocolDependenciesAppliedToGlobalProps() {
+        // When protocol=pipe is specified globally, socketFactory should be auto-set in global props too
+        String cs = "jdbc:mysql://host1:3306,host2:3306/db?protocol=pipe";
+        ConnectionUrl url = ConnectionUrl.getConnectionUrlInstance(cs, null);
+        Properties props = url.getConnectionArgumentsAsProperties();
+        assertEquals("com.mysql.cj.protocol.NamedPipeSocketFactory",
+                props.getProperty(PropertyKey.socketFactory.getKeyName()));
+    }
+    
     /**
      * Tests jdbc:mysql+srv: connection strings.
      */


### PR DESCRIPTION
When using a multi-host JDBC URL (failover) with the legacy property value zeroDateTimeBehavior=convertToNull, the driver throws an exception stating the only acceptable values are CONVERT_TO_NULL, EXCEPTION, or ROUND. The same property/value works with a single-host URL.
Root cause:
Legacy value translation is applied only per-host in fixHostInfo() via replaceLegacyPropertyValues(hostProps).
In the failover path, FailoverConnectionProxy initializes properties from ConnectionUrl.getConnectionArgumentsAsProperties(), which returns the global properties map (this.properties) that has not been passed through replaceLegacyPropertyValues.
As a result, convertToNull is not normalized to CONVERT_TO_NULL and enum parsing fails in EnumPropertyDefinition.
Impact:
Backward-compatible URLs that rely on convertToNull fail in multi-host scenarios, but succeed in single-host scenarios, creating inconsistent behavior.
Exception (abridged):
com.mysql.cj.exceptions.CJException: The connection property 'zeroDateTimeBehavior' acceptable values are: 'CONVERT_TO_NULL', 'EXCEPTION' or 'ROUND'. The value 'convertToNull' is not acceptable.
