### PR TITLE
Fix MySQLStatementCancelledException created with null SQLState

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/exceptions/OperationCancelledException.java
+++ b/src/main/core-api/java/com/mysql/cj/exceptions/OperationCancelledException.java
@@ -28,18 +28,22 @@ public class OperationCancelledException extends CJException {
 
     public OperationCancelledException() {
         super(Messages.getString("MySQLStatementCancelledException.0"));
+        setSQLState(MysqlErrorNumbers.SQLSTATE_MYSQL_QUERY_INTERRUPTED);
     }
 
     public OperationCancelledException(String message) {
         super(message);
+        setSQLState(MysqlErrorNumbers.SQLSTATE_MYSQL_QUERY_INTERRUPTED);
     }
 
     public OperationCancelledException(Throwable cause) {
         super(cause);
+        setSQLState(MysqlErrorNumbers.SQLSTATE_MYSQL_QUERY_INTERRUPTED);
     }
 
     public OperationCancelledException(String message, Throwable cause) {
         super(message, cause);
+        setSQLState(MysqlErrorNumbers.SQLSTATE_MYSQL_QUERY_INTERRUPTED);
     }
 
 }

--- a/src/main/user-impl/java/com/mysql/cj/jdbc/exceptions/SQLExceptionsMapping.java
+++ b/src/main/user-impl/java/com/mysql/cj/jdbc/exceptions/SQLExceptionsMapping.java
@@ -99,10 +99,10 @@ public class SQLExceptionsMapping {
             return new PacketTooBigException(ex.getMessage());
 
         } else if (ex instanceof OperationCancelledException) {
-            return new MySQLStatementCancelledException(ex.getMessage());
+            return new MySQLStatementCancelledException(ex.getMessage(), ((CJException) ex).getSQLState(), ((CJException) ex).getVendorCode());
 
         } else if (ex instanceof CJTimeoutException) {
-            return new MySQLTimeoutException(ex.getMessage());
+            return new MySQLTimeoutException(ex.getMessage(), ((CJException) ex).getSQLState(), ((CJException) ex).getVendorCode());
 
         } else if (ex instanceof CJOperationNotSupportedException) {
             return new OperationNotSupportedException(ex.getMessage());


### PR DESCRIPTION
## Summary

- `SQLExceptionsMapping.translateException()` used single-arg constructors for `MySQLStatementCancelledException` and `MySQLTimeoutException`, dropping the SQLState and vendorCode from the underlying `CJException`
- `OperationCancelledException` inherited the generic "S1000" default from `CJException` instead of setting "70100" (`SQLSTATE_MYSQL_QUERY_INTERRUPTED`)

This caused `MySQLStatementCancelledException.getSQLState()` to return `null`, breaking frameworks like Spring JDBC that rely on SQLState for exception classification (producing `UncategorizedSQLException` instead of properly categorized exceptions).

## Changes

- **`OperationCancelledException`**: set default SQLState to `MysqlErrorNumbers.SQLSTATE_MYSQL_QUERY_INTERRUPTED` ("70100") in all constructors
- **`SQLExceptionsMapping.translateException()`**: propagate SQLState and vendorCode when creating `MySQLStatementCancelledException` and `MySQLTimeoutException`

## Test plan

- Verify `MySQLStatementCancelledException.getSQLState()` returns "70100" after `Statement.cancel()` interrupts a running query
- Verify `MySQLTimeoutException.getSQLState()` is not null after a query timeout

Fixes: https://github.com/mysql/mysql-connector-j/issues/125