### PR TITLE
Implement extended capability flags and metadata caching

### DIFF
--- a/src/main/core-api/java/com/mysql/cj/protocol/ServerCapabilities.java
+++ b/src/main/core-api/java/com/mysql/cj/protocol/ServerCapabilities.java
@@ -33,6 +33,10 @@ public interface ServerCapabilities {
 
     ServerVersion getServerVersion();
 
+    default int getExtendedCapabilityFlags() {
+        return 0;
+    }
+
     long getThreadId();
 
     void setThreadId(long threadId);

--- a/src/main/core-api/java/com/mysql/cj/protocol/ServerSession.java
+++ b/src/main/core-api/java/com/mysql/cj/protocol/ServerSession.java
@@ -108,6 +108,18 @@ public interface ServerSession {
 
     void setClientParam(long clientParam);
 
+    default int getClientParamExtended() {
+        return 0;
+    }
+
+    default void setClientParamExtended(int clientParamExtended) {
+        // no-op by default; protocol implementations that negotiate extended capabilities override this.
+    }
+
+    default boolean hasCacheMetadataEnabled() {
+        return false;
+    }
+
     boolean hasLongColumnInfo();
 
     boolean useMultiResults();

--- a/src/main/core-impl/java/com/mysql/cj/ServerPreparedQuery.java
+++ b/src/main/core-impl/java/com/mysql/cj/ServerPreparedQuery.java
@@ -330,6 +330,11 @@ public class ServerPreparedQuery extends ClientPreparedQuery {
             T rs = this.session.getProtocol().readAllResults(maxRowsToRetrieve, createStreamingResultSet, resultPacket, true,
                     metadata != null ? metadata : this.resultFields, resultSetFactory);
 
+            // Refresh the cached result-set metadata from the first resultset so that future executes, not PREPARE-time copy
+            if (rs != null && this.resultFields != null) {
+                this.resultFields = rs.getColumnDefinition();
+            }
+
             if (this.session.shouldIntercept()) {
                 T interceptedResults = this.session.invokeQueryInterceptorsPost(this::getOriginalSql, this, rs, true);
 

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/BinaryResultsetReader.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/BinaryResultsetReader.java
@@ -56,8 +56,18 @@ public class BinaryResultsetReader implements ProtocolEntityReader<Resultset, Na
         if (columnCount > 0) {
             // Build a result set with rows.
 
+            // When CLIENT_CACHE_METADATA is negotiated the server inserts a 1-byte flag after the column count:
+            //   1 = column definitions follow (regular protocol)
+            //   0 = column definitions are skipped because metadata is unchanged
+            boolean metadataFollows = true;
+            if (this.protocol.getServerSession().hasCacheMetadataEnabled()) {
+                metadataFollows = resultPacket.readInteger(IntegerDataType.INT1) != 0;
+            }
+
             // Read in the column information
-            ColumnDefinition cdef = this.protocol.read(ColumnDefinition.class, new MergingColumnDefinitionFactory(columnCount, metadata));
+            ColumnDefinition cdef = metadataFollows //
+                    ? this.protocol.read(ColumnDefinition.class, new MergingColumnDefinitionFactory(columnCount, metadata)) //
+                    : metadata;
 
             boolean isCursorPossible = this.protocol.getPropertySet().getBooleanProperty(PropertyKey.useCursorFetch).getValue()
                     && resultSetFactory.getResultSetType() == Type.FORWARD_ONLY && resultSetFactory.getFetchSize() > 0;

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeAuthenticationProvider.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeAuthenticationProvider.java
@@ -159,7 +159,7 @@ public class NativeAuthenticationProvider implements AuthenticationProvider<Nati
         this.useConnectWithDb = this.database != null && this.database.length() > 0
                 && !this.propertySet.getBooleanProperty(PropertyKey.createDatabaseIfNotExist).getValue();
 
-        long clientParam = capabilityFlags & NativeServerSession.CLIENT_LONG_PASSWORD //
+        long clientParam = capabilityFlags & NativeServerSession.CLIENT_MYSQL //
                 | (this.propertySet.getBooleanProperty(PropertyKey.useAffectedRows).getValue() ? //
                         0 : capabilityFlags & NativeServerSession.CLIENT_FOUND_ROWS) //
                 | capabilityFlags & NativeServerSession.CLIENT_LONG_FLAG //
@@ -193,6 +193,9 @@ public class NativeAuthenticationProvider implements AuthenticationProvider<Nati
                 | capabilityFlags & NativeServerSession.CLIENT_MULTI_FACTOR_AUTHENTICATION;
 
         sessState.setClientParam(clientParam);
+
+        int clientParamExtended = capabilities.getExtendedCapabilityFlags() & NativeServerSession.CLIENT_CACHE_METADATA;
+        sessState.setClientParamExtended(clientParamExtended);
 
         /* First, negotiate SSL connection */
         if ((clientParam & NativeServerSession.CLIENT_SSL) != 0) {
@@ -614,7 +617,8 @@ public class NativeAuthenticationProvider implements AuthenticationProvider<Nati
         last_sent.writeInteger(IntegerDataType.INT4, clientParam);
         last_sent.writeInteger(IntegerDataType.INT4, NativeConstants.MAX_PACKET_SIZE);
         last_sent.writeInteger(IntegerDataType.INT1, collationIndex);
-        last_sent.writeBytes(StringLengthDataType.STRING_FIXED, new byte[23]);   // Set of bytes reserved for future use.
+        last_sent.writeBytes(StringLengthDataType.STRING_FIXED, new byte[19]);
+        last_sent.writeInteger(IntegerDataType.INT4, serverSession.getClientParamExtended());
 
         // User/Password data
         last_sent.writeBytes(StringSelfDataType.STRING_TERM, StringUtils.getBytes(this.username, enc));

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeCapabilities.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeCapabilities.java
@@ -38,6 +38,7 @@ public class NativeCapabilities implements ServerCapabilities {
     private long threadId = -1;
     private String seed;
     private int capabilityFlags;
+    private int extendedCapabilityFlags;
     private int serverDefaultCollationIndex;
     private int statusFlags = 0;
     private int authPluginDataLength = 0;
@@ -50,7 +51,8 @@ public class NativeCapabilities implements ServerCapabilities {
         this.protocolVersion = (byte) initialHandshakePacket.readInteger(IntegerDataType.INT1);
 
         try {
-            this.serverVersion = ServerVersion.parseVersion(initialHandshakePacket.readString(StringSelfDataType.STRING_TERM, "ASCII"));
+            String versionString = initialHandshakePacket.readString(StringSelfDataType.STRING_TERM, "ASCII");
+            this.serverVersion = ServerVersion.parseVersion(versionString);
 
             // read connection id
             this.threadId = initialHandshakePacket.readInteger(IntegerDataType.INT4);
@@ -85,8 +87,10 @@ public class NativeCapabilities implements ServerCapabilities {
                 // read filler ([00])
                 initialHandshakePacket.readInteger(IntegerDataType.INT1);
             }
-            // next 10 bytes are reserved (all [00])
-            initialHandshakePacket.setPosition(initialHandshakePacket.getPosition() + 10);
+            // next 6 bytes are reserved (all [00])
+            initialHandshakePacket.setPosition(initialHandshakePacket.getPosition() + 6);
+            // read extended flag (4 bytes)
+            this.extendedCapabilityFlags = (int) initialHandshakePacket.readInteger(IntegerDataType.INT4);
 
             this.serverHasFracSecsSupport = this.serverVersion.meetsMinimum(new ServerVersion(5, 6, 4));
         } catch (Throwable t) {
@@ -118,6 +122,11 @@ public class NativeCapabilities implements ServerCapabilities {
     @Override
     public ServerVersion getServerVersion() {
         return this.serverVersion;
+    }
+
+    @Override
+    public int getExtendedCapabilityFlags() {
+        return this.extendedCapabilityFlags;
     }
 
     @Override

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeProtocol.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeProtocol.java
@@ -348,7 +348,8 @@ public class NativeProtocol extends AbstractProtocol<NativePacketPayload> implem
         packet.writeInteger(IntegerDataType.INT4, clientParam);
         packet.writeInteger(IntegerDataType.INT4, NativeConstants.MAX_PACKET_SIZE);
         packet.writeInteger(IntegerDataType.INT1, this.serverSession.getCharsetSettings().configurePreHandshake(false));
-        packet.writeBytes(StringLengthDataType.STRING_FIXED, new byte[23]);  // Set of bytes reserved for future use.
+        packet.writeBytes(StringLengthDataType.STRING_FIXED, new byte[19]);  // Set of bytes reserved for future use.
+        packet.writeInteger(IntegerDataType.INT4, this.serverSession.getClientParamExtended());
 
         send(packet, packet.getPosition());
 

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeServerSession.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/NativeServerSession.java
@@ -48,7 +48,7 @@ public class NativeServerSession implements ServerSession {
     public static final int SERVER_QUERY_WAS_SLOW = 2048;
     public static final int SERVER_SESSION_STATE_CHANGED = 1 << 14; // 16384
 
-    public static final int CLIENT_LONG_PASSWORD = 0x00000001; /* new more secure passwords */
+    public static final int CLIENT_MYSQL = 0x00000001; /* server is MySQL; cleared by MariaDB */
     public static final int CLIENT_FOUND_ROWS = 0x00000002;
     public static final int CLIENT_LONG_FLAG = 0x00000004; /* Get all column flags */
     public static final int CLIENT_CONNECT_WITH_DB = 0x00000008;
@@ -72,11 +72,17 @@ public class NativeServerSession implements ServerSession {
     public static final int CLIENT_QUERY_ATTRIBUTES = 0x08000000;
     public static final int CLIENT_MULTI_FACTOR_AUTHENTICATION = 0x10000000;
 
+    /**
+     * extended capability bits (sent and received as a separate 4-byte word in the handshake).
+     */
+    public static final int CLIENT_CACHE_METADATA = 0x00000010; // 1 << 4 in extended-cap space
+
     private PropertySet propertySet;
     private NativeCapabilities capabilities;
     private int oldStatusFlags = 0;
     private int statusFlags = 0;
     private long clientParam = 0;
+    private int clientParamExtended = 0;
     private NativeServerSessionStateController serverSessionStateController;
 
     /** The map of server variables that we retrieve at connection init. */
@@ -192,6 +198,21 @@ public class NativeServerSession implements ServerSession {
     @Override
     public void setClientParam(long clientParam) {
         this.clientParam = clientParam;
+    }
+
+    @Override
+    public int getClientParamExtended() {
+        return this.clientParamExtended;
+    }
+
+    @Override
+    public void setClientParamExtended(int clientParamExtended) {
+        this.clientParamExtended = clientParamExtended;
+    }
+
+    @Override
+    public boolean hasCacheMetadataEnabled() {
+        return (this.clientParamExtended & CLIENT_CACHE_METADATA) != 0;
     }
 
     @Override

--- a/src/main/protocol-impl/java/com/mysql/cj/protocol/a/TextResultsetReader.java
+++ b/src/main/protocol-impl/java/com/mysql/cj/protocol/a/TextResultsetReader.java
@@ -54,6 +54,11 @@ public class TextResultsetReader implements ProtocolEntityReader<Resultset, Nati
         if (columnCount > 0) {
             // Build a result set with rows.
 
+            if (this.protocol.getServerSession().hasCacheMetadataEnabled()) {
+                // metadata_follows byte: COM_QUERY has no cached metadata to reuse, so the server always sets it to 1. Consume the byte to keep the stream aligned.
+                resultPacket.readInteger(IntegerDataType.INT1);
+            }
+
             // Read in the column information
             ColumnDefinition cdef = this.protocol.read(ColumnDefinition.class, new ColumnDefinitionFactory(columnCount, metadata));
 


### PR DESCRIPTION
Implement MariaDB `CLIENT_CACHE_METADATA` prepared-statement metadata skip optimization

### Summary
MariaDB 10.6+ defines an extended capability flag `CLIENT_CACHE_METADATA`. When negotiated, the server omits column definitions in `COM_STMT_EXECUTE` responses whose metadata is unchanged from the previous response, signalling reuse via a 1-byte metadata_follows flag inserted after the column count in every resultset header.

This PR negotiates the capability against MariaDB servers and consumes the flag in the binary and text resultset readers, reusing the cached column definitions from `COM_STMT_PREPARE` when the server signals reuse and re-reading them otherwise.

### Background

The standard capability flag are supported on 4 bytes. MariaDB 10.2+ repurposes the last 4 bytes of the 10-byte reserved tail of the initial handshake (and the equivalent slot in the client's HandshakeResponse / SSLRequest) to carry 4 additional capability flags. MySQL servers leave those bytes zero. ([protocol description](https://mariadb.com/docs/server/reference/clientserver-protocol/4-server-response-packets/result-set-packets))

This PR adds support for that extension.

### Compatibility

* MySQL servers: the extended-cap slot is read as zero, the client's extended caps are sent as zero, the metadata-follows path is never entered. Identical wire behaviour to today.
* MariaDB 10.5 and earlier: the server does not advertise `CLIENT_CACHE_METADATA`, so the intersection at handshake yields zero on the client side and the path stays dormant.
* MariaDB 10.6+: capability is negotiated, metadata skipped per-execute.

### Performance results

a [JMH benchmark](https://github.com/openjdk/jmh) on `SELECT * FROM test100` (100 INT columns, MariaDB 12.3, localhost) : 

```
private void run(Connection con, Blackhole blackhole) throws Throwable {
        try (PreparedStatement prep = con.prepareStatement("SELECT * FROM test100")) {
            try (ResultSet rs = prep.executeQuery()) {
                rs.next();
                for (int i = 0; i < 100; i++) {
                    blackhole.consume(rs.getInt(i + 1));
                }
            }
        }
    }
```

  | baseline 9.7.0 | this PR | delta
-- | -- | -- | --
TEXT QUERY | 12 544 ops/s | 12 556 ops/s | no changes
EXECUTE | 14 302 ops/s | 19 014 ops/s | +33% performance gain
PREPARE + EXECUTE + CLOSE | 7 694 ops/s | 8 229 ops/s | +7% performance gain

(ops meaning operations per second, so higher the better)

This is only when using MariaDB server, but MySQL Connector/J is already deployed against MariaDB. For those users the connector today silently ignores an optimization the server is willing to give them. Closing the gap is a quality-of-implementation improvement for an existing deployment pattern. 

### Bug fix included: cached metadata not refreshed after server-side reprepare

The PR also fixes a pre-existing correctness gap independent of `CLIENT_CACHE_METADATA`.

MySQL automatically re-prepares a server-side prepared statement when a DDL invalidates it ([WL#4166: Prepared statements: automatic re-prepare](https://dev.mysql.com/worklog/task/?id=4166)). The re-prepared statement may have different column metadata, which the server propagates by sending fresh ColumnDefinition packets in the next `COM_STMT_EXECUTE` response.  `ServerPreparedQuery.resultFields` was never updated, resulting in ServerPreparedStatement.getMetaData() returning only PREPARE results. 